### PR TITLE
refactor: remove circular reference allowance

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,7 +12,6 @@ spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
 #spring.jpa.open-in-view=false
 spring.output.ansi.enabled=ALWAYS
-spring.main.allow-circular-references=true
 
 #POOL CONNECTION
 spring.datasource.hikari.maximum-pool-size=20


### PR DESCRIPTION
## Summary
- remove spring.main.allow-circular-references property from application configuration

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for me.quadradev:api:0.0.1-SNAPSHOT)*

------
https://chatgpt.com/codex/tasks/task_e_6893b8bcf3008330a39a2d4dd8794ee6