### PR TITLE
chore: use PathPattern path matching

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -26,7 +26,6 @@ server.port=${SERVER_PORT}
 cors.allowed-origins=${CORS_ALLOWED_ORIGINS:http://localhost:3000}
 
 #SWAGGER
-spring.mvc.pathmatch.matching-strategy=ant-path-matcher
 
 #MAIL
 spring.mail.host=smtp.gmail.com

--- a/src/test/java/me/quadradev/api/PathPatternRoutingTests.java
+++ b/src/test/java/me/quadradev/api/PathPatternRoutingTests.java
@@ -1,0 +1,37 @@
+package me.quadradev.api;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(classes = {ApiApplication.class, PathPatternRoutingTests.TestController.class})
+@AutoConfigureMockMvc
+class PathPatternRoutingTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @RestController
+    static class TestController {
+        @GetMapping("/payments/{id}")
+        String getPayment(@PathVariable String id) {
+            return id;
+        }
+    }
+
+    @Test
+    void requestWithDotInPathIsHandled() throws Exception {
+        mockMvc.perform(get("/payments/123.456"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("123.456"));
+    }
+}


### PR DESCRIPTION
## Summary
- remove legacy AntPathMatcher setting
- add MockMvc test to validate PathPattern routing

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.4)*

------
https://chatgpt.com/codex/tasks/task_e_6893bc1304e48330872f573cd24afcc5