### PR TITLE
Load .env via PropertySource

### DIFF
--- a/src/main/java/me/quadradev/api/common/DotenvInitializer.java
+++ b/src/main/java/me/quadradev/api/common/DotenvInitializer.java
@@ -1,14 +1,26 @@
 package me.quadradev.api.common;
 
 import io.github.cdimascio.dotenv.Dotenv;
+import java.util.HashMap;
+import java.util.Map;
 import org.springframework.context.ApplicationContextInitializer;
 import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.MutablePropertySources;
+import org.springframework.core.env.ConfigurableEnvironment;
 
 public class DotenvInitializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
     @Override
     public void initialize(ConfigurableApplicationContext applicationContext) {
         Dotenv dotenv = Dotenv.configure().directory("./").ignoreIfMissing().load();
-        dotenv.entries().forEach(entry -> System.setProperty(entry.getKey(), entry.getValue()));
-
+        ConfigurableEnvironment environment = applicationContext.getEnvironment();
+        MutablePropertySources propertySources = environment.getPropertySources();
+        Map<String, Object> dotenvMap = new HashMap<>();
+        dotenv.entries().forEach(entry -> {
+            if (!environment.containsProperty(entry.getKey())) {
+                dotenvMap.put(entry.getKey(), entry.getValue());
+            }
+        });
+        propertySources.addLast(new MapPropertySource("dotenv", dotenvMap));
     }
 }

--- a/src/test/java/me/quadradev/api/common/DotenvInitializerTest.java
+++ b/src/test/java/me/quadradev/api/common/DotenvInitializerTest.java
@@ -1,0 +1,48 @@
+package me.quadradev.api.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.context.support.GenericApplicationContext;
+
+class DotenvInitializerTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void loadsDotenvProperties() throws IOException {
+        Files.writeString(tempDir.resolve(".env"), "TEST_KEY=dotenvValue\n");
+        String originalUserDir = System.getProperty("user.dir");
+        GenericApplicationContext context = new GenericApplicationContext();
+        try {
+            System.setProperty("user.dir", tempDir.toString());
+            new DotenvInitializer().initialize(context);
+            assertThat(context.getEnvironment().getProperty("TEST_KEY")).isEqualTo("dotenvValue");
+        } finally {
+            System.setProperty("user.dir", originalUserDir);
+            context.close();
+        }
+    }
+
+    @Test
+    void systemPropertiesTakePrecedence() throws IOException {
+        Files.writeString(tempDir.resolve(".env"), "TEST_KEY=dotenvValue\n");
+        String originalUserDir = System.getProperty("user.dir");
+        GenericApplicationContext context = new GenericApplicationContext();
+        try {
+            System.setProperty("user.dir", tempDir.toString());
+            System.setProperty("TEST_KEY", "systemValue");
+            new DotenvInitializer().initialize(context);
+            assertThat(context.getEnvironment().getProperty("TEST_KEY")).isEqualTo("systemValue");
+        } finally {
+            System.clearProperty("TEST_KEY");
+            System.setProperty("user.dir", originalUserDir);
+            context.close();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- load Dotenv entries into a MapPropertySource and skip keys already defined
- add tests covering dotenv loading and property precedence

## Testing
- `mvn test` *(fails: Could not resolve parent POM due to network is unreachable)*
- `mvn -o test` *(fails: Non-resolvable parent POM; artifact not downloaded)*

------
https://chatgpt.com/codex/tasks/task_e_6893bc021e58833084ffe2c393b1c671