### PR TITLE
Add user domain and application flow

### DIFF
--- a/src/main/java/me/quadradev/api/adapters/incoming/rest/UserController.java
+++ b/src/main/java/me/quadradev/api/adapters/incoming/rest/UserController.java
@@ -1,0 +1,39 @@
+package me.quadradev.api.adapters.incoming.rest;
+
+import me.quadradev.api.adapters.incoming.rest.dto.CreateUserRequest;
+import me.quadradev.api.application.ports.in.CreateUserUseCase;
+import me.quadradev.api.application.ports.in.GetUserUseCase;
+import me.quadradev.api.domain.user.User;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+
+/**
+ * REST controller exposing user related endpoints.
+ */
+@RestController
+@RequestMapping("/users")
+public class UserController {
+
+    private final CreateUserUseCase createUserUseCase;
+    private final GetUserUseCase getUserUseCase;
+
+    public UserController(CreateUserUseCase createUserUseCase, GetUserUseCase getUserUseCase) {
+        this.createUserUseCase = createUserUseCase;
+        this.getUserUseCase = getUserUseCase;
+    }
+
+    @PostMapping
+    public ResponseEntity<User> create(@RequestBody CreateUserRequest request) {
+        User user = createUserUseCase.createUser(request.name(), request.email());
+        return ResponseEntity.created(URI.create("/users/" + user.id())).body(user);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<User> getById(@PathVariable Long id) {
+        return getUserUseCase.getUser(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+}

--- a/src/main/java/me/quadradev/api/adapters/incoming/rest/dto/CreateUserRequest.java
+++ b/src/main/java/me/quadradev/api/adapters/incoming/rest/dto/CreateUserRequest.java
@@ -1,0 +1,7 @@
+package me.quadradev.api.adapters.incoming.rest.dto;
+
+/**
+ * DTO representing the payload required to create a new user.
+ */
+public record CreateUserRequest(String name, String email) {
+}

--- a/src/main/java/me/quadradev/api/application/ports/in/CreateUserUseCase.java
+++ b/src/main/java/me/quadradev/api/application/ports/in/CreateUserUseCase.java
@@ -1,0 +1,10 @@
+package me.quadradev.api.application.ports.in;
+
+import me.quadradev.api.domain.user.User;
+
+/**
+ * Use case for creating a new user.
+ */
+public interface CreateUserUseCase {
+    User createUser(String name, String email);
+}

--- a/src/main/java/me/quadradev/api/application/ports/in/GetUserUseCase.java
+++ b/src/main/java/me/quadradev/api/application/ports/in/GetUserUseCase.java
@@ -1,0 +1,12 @@
+package me.quadradev.api.application.ports.in;
+
+import me.quadradev.api.domain.user.User;
+
+import java.util.Optional;
+
+/**
+ * Use case for retrieving a user by its identifier.
+ */
+public interface GetUserUseCase {
+    Optional<User> getUser(Long id);
+}

--- a/src/main/java/me/quadradev/api/application/ports/out/UserRepository.java
+++ b/src/main/java/me/quadradev/api/application/ports/out/UserRepository.java
@@ -1,0 +1,13 @@
+package me.quadradev.api.application.ports.out;
+
+import me.quadradev.api.domain.user.User;
+
+import java.util.Optional;
+
+/**
+ * Port for persisting and retrieving users.
+ */
+public interface UserRepository {
+    User save(User user);
+    Optional<User> findById(Long id);
+}

--- a/src/main/java/me/quadradev/api/application/user/UserService.java
+++ b/src/main/java/me/quadradev/api/application/user/UserService.java
@@ -1,0 +1,33 @@
+package me.quadradev.api.application.user;
+
+import me.quadradev.api.application.ports.in.CreateUserUseCase;
+import me.quadradev.api.application.ports.in.GetUserUseCase;
+import me.quadradev.api.application.ports.out.UserRepository;
+import me.quadradev.api.domain.user.User;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+/**
+ * Implementation of user-related use cases.
+ */
+@Service
+public class UserService implements CreateUserUseCase, GetUserUseCase {
+
+    private final UserRepository userRepository;
+
+    public UserService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public User createUser(String name, String email) {
+        User user = new User(null, name, email);
+        return userRepository.save(user);
+    }
+
+    @Override
+    public Optional<User> getUser(Long id) {
+        return userRepository.findById(id);
+    }
+}

--- a/src/main/java/me/quadradev/api/domain/user/User.java
+++ b/src/main/java/me/quadradev/api/domain/user/User.java
@@ -1,0 +1,7 @@
+package me.quadradev.api.domain.user;
+
+/**
+ * Domain entity representing a user of the system.
+ */
+public record User(Long id, String name, String email) {
+}

--- a/src/main/java/me/quadradev/api/infrastructure/persistence/InMemoryUserRepository.java
+++ b/src/main/java/me/quadradev/api/infrastructure/persistence/InMemoryUserRepository.java
@@ -1,0 +1,34 @@
+package me.quadradev.api.infrastructure.persistence;
+
+import me.quadradev.api.application.ports.out.UserRepository;
+import me.quadradev.api.domain.user.User;
+import org.springframework.stereotype.Repository;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Simple in-memory implementation of {@link UserRepository} for demonstration
+ * purposes.
+ */
+@Repository
+public class InMemoryUserRepository implements UserRepository {
+
+    private final Map<Long, User> storage = new ConcurrentHashMap<>();
+    private final AtomicLong sequence = new AtomicLong();
+
+    @Override
+    public User save(User user) {
+        Long id = user.id() != null ? user.id() : sequence.incrementAndGet();
+        User persisted = new User(id, user.name(), user.email());
+        storage.put(id, persisted);
+        return persisted;
+    }
+
+    @Override
+    public Optional<User> findById(Long id) {
+        return Optional.ofNullable(storage.get(id));
+    }
+}

--- a/src/test/java/me/quadradev/api/application/user/UserServiceTest.java
+++ b/src/test/java/me/quadradev/api/application/user/UserServiceTest.java
@@ -1,0 +1,33 @@
+package me.quadradev.api.application.user;
+
+import me.quadradev.api.application.ports.out.UserRepository;
+import me.quadradev.api.domain.user.User;
+import me.quadradev.api.infrastructure.persistence.InMemoryUserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class UserServiceTest {
+
+    private UserService userService;
+
+    @BeforeEach
+    void setUp() {
+        UserRepository repository = new InMemoryUserRepository();
+        userService = new UserService(repository);
+    }
+
+    @Test
+    void createAndRetrieveUser() {
+        User created = userService.createUser("Alice", "alice@example.com");
+        assertNotNull(created.id());
+
+        Optional<User> retrieved = userService.getUser(created.id());
+        assertTrue(retrieved.isPresent());
+        assertEquals("Alice", retrieved.get().name());
+        assertEquals("alice@example.com", retrieved.get().email());
+    }
+}


### PR DESCRIPTION
## Summary
- add domain `User` entity
- expose user use cases and REST endpoints
- provide in-memory persistence and service tests

## Testing
- `mvn -q test` *(fails: Network is unreachable while resolving Spring Boot parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6893c93316808330a3ca7e0fb3634772