### PR TITLE
feat: add generic API response wrapper

### DIFF
--- a/src/main/java/me/quadradev/common/util/ApiResponse.java
+++ b/src/main/java/me/quadradev/common/util/ApiResponse.java
@@ -1,12 +1,48 @@
 package me.quadradev.common.util;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
+@Builder
+@NoArgsConstructor
 @AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ApiResponse<T> {
     private boolean success;
+    private int status;
     private String message;
     private T data;
+    private Object error;
+
+    public static <T> ApiResponse<T> ok(String message, T data) {
+        return ApiResponse.<T>builder()
+                .success(true)
+                .status(200)
+                .message(message)
+                .data(data)
+                .build();
+    }
+
+    public static <T> ApiResponse<T> created(String message, T data) {
+        return ApiResponse.<T>builder()
+                .success(true)
+                .status(201)
+                .message(message)
+                .data(data)
+                .build();
+    }
+
+    public static <T> ApiResponse<T> error(int status, String message, Object errorDetails) {
+        return ApiResponse.<T>builder()
+                .success(false)
+                .status(status)
+                .message(message)
+                .error(errorDetails)
+                .build();
+    }
 }
+


### PR DESCRIPTION
## Summary
- create generic ApiResponse class with status, message, data and error fields
- add factory helpers for ok, created and error responses

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6893ee29eea48330a63309fdf3ca3281