### PR TITLE
feat: add user soft delete

### DIFF
--- a/src/main/java/me/quadradev/application/core/model/User.java
+++ b/src/main/java/me/quadradev/application/core/model/User.java
@@ -22,6 +22,10 @@ public class User {
 
     private String email;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private UserStatus status = UserStatus.ACTIVE;
+
     @OneToOne(cascade = CascadeType.ALL)
     @JoinColumn(name = "person_id", referencedColumnName = "id")
     private Person person;

--- a/src/main/java/me/quadradev/application/core/model/UserStatus.java
+++ b/src/main/java/me/quadradev/application/core/model/UserStatus.java
@@ -1,0 +1,7 @@
+package me.quadradev.application.core.model;
+
+public enum UserStatus {
+    ACTIVE,
+    INACTIVE
+}
+

--- a/src/main/java/me/quadradev/application/core/repository/UserRepository.java
+++ b/src/main/java/me/quadradev/application/core/repository/UserRepository.java
@@ -1,9 +1,13 @@
 package me.quadradev.application.core.repository;
 
 import me.quadradev.application.core.model.User;
+import me.quadradev.application.core.model.UserStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
+    List<User> findByStatus(UserStatus status);
 }

--- a/src/main/java/me/quadradev/application/core/service/UserService.java
+++ b/src/main/java/me/quadradev/application/core/service/UserService.java
@@ -2,8 +2,11 @@ package me.quadradev.application.core.service;
 
 import lombok.RequiredArgsConstructor;
 import me.quadradev.application.core.model.User;
+import me.quadradev.application.core.model.UserStatus;
 import me.quadradev.application.core.repository.UserRepository;
+import me.quadradev.common.exception.ApiException;
 import org.springframework.stereotype.Service;
+import org.springframework.http.HttpStatus;
 
 import java.util.List;
 import java.util.Optional;
@@ -26,7 +29,10 @@ public class UserService {
         return userRepository.save(user);
     }
 
-    public void deleteUser(Long id) {
-        userRepository.deleteById(id);
+    public void deactivateUser(Long id) {
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new ApiException("User not found", HttpStatus.NOT_FOUND));
+        user.setStatus(UserStatus.INACTIVE);
+        userRepository.save(user);
     }
 }


### PR DESCRIPTION
## Summary
- add `UserStatus` enum to represent user states
- track status in `User` entity with default `ACTIVE`
- replace delete with deactivate logic in user service and repository

## Testing
- `./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.11/apache-maven-3.9.11-bin.zip)*
- `mvn -q test` *(fails: Non-resolvable parent POM ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6893f4cde75c833094c54a921180a757