### PR TITLE
feat: add dynamic user search with JPA specifications

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,11 @@
                             <groupId>org.projectlombok</groupId>
                             <artifactId>lombok</artifactId>
                         </path>
+                        <path>
+                            <groupId>org.hibernate.orm</groupId>
+                            <artifactId>hibernate-jpamodelgen</artifactId>
+                            <version>${hibernate.version}</version>
+                        </path>
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>

--- a/src/main/java/me/quadradev/application/core/controller/UserController.java
+++ b/src/main/java/me/quadradev/application/core/controller/UserController.java
@@ -2,7 +2,9 @@ package me.quadradev.application.core.controller;
 
 import lombok.RequiredArgsConstructor;
 import me.quadradev.application.core.model.User;
+import me.quadradev.application.core.model.UserStatus;
 import me.quadradev.application.core.service.UserService;
+import me.quadradev.common.util.ApiResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -32,5 +34,14 @@ public class UserController {
     public ResponseEntity<User> create(@RequestBody User user) {
         User created = userService.createUser(user);
         return ResponseEntity.status(HttpStatus.CREATED).body(created);
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<ApiResponse<List<User>>> searchUsers(
+            @RequestParam(required = false) String email,
+            @RequestParam(required = false) UserStatus status,
+            @RequestParam(required = false) String name) {
+        List<User> users = userService.searchUsers(email, status, name);
+        return ResponseEntity.ok(ApiResponse.ok("Users retrieved", users));
     }
 }

--- a/src/main/java/me/quadradev/application/core/repository/UserRepository.java
+++ b/src/main/java/me/quadradev/application/core/repository/UserRepository.java
@@ -3,11 +3,12 @@ package me.quadradev.application.core.repository;
 import me.quadradev.application.core.model.User;
 import me.quadradev.application.core.model.UserStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
 @Repository
-public interface UserRepository extends JpaRepository<User, Long> {
+public interface UserRepository extends JpaRepository<User, Long>, JpaSpecificationExecutor<User> {
     List<User> findByStatus(UserStatus status);
 }

--- a/src/main/java/me/quadradev/application/core/service/UserService.java
+++ b/src/main/java/me/quadradev/application/core/service/UserService.java
@@ -4,9 +4,11 @@ import lombok.RequiredArgsConstructor;
 import me.quadradev.application.core.model.User;
 import me.quadradev.application.core.model.UserStatus;
 import me.quadradev.application.core.repository.UserRepository;
+import me.quadradev.application.core.specification.UserSpecifications;
 import me.quadradev.common.exception.ApiException;
 import org.springframework.stereotype.Service;
 import org.springframework.http.HttpStatus;
+import org.springframework.data.jpa.domain.Specification;
 
 import java.util.List;
 import java.util.Optional;
@@ -27,6 +29,13 @@ public class UserService {
 
     public User createUser(User user) {
         return userRepository.save(user);
+    }
+
+    public List<User> searchUsers(String email, UserStatus status, String name) {
+        Specification<User> spec = Specification.where(UserSpecifications.hasEmail(email))
+                .and(UserSpecifications.hasStatus(status))
+                .and(UserSpecifications.hasFirstName(name));
+        return userRepository.findAll(spec);
     }
 
     public void deactivateUser(Long id) {

--- a/src/main/java/me/quadradev/application/core/specification/UserSpecifications.java
+++ b/src/main/java/me/quadradev/application/core/specification/UserSpecifications.java
@@ -1,0 +1,36 @@
+package me.quadradev.application.core.specification;
+
+import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.JoinType;
+import me.quadradev.application.core.model.*;
+import org.springframework.data.jpa.domain.Specification;
+
+public class UserSpecifications {
+    public static Specification<User> hasEmail(String email) {
+        return (root, query, cb) -> {
+            if (email == null || email.isBlank()) {
+                return null;
+            }
+            return cb.equal(root.get(User_.email), email);
+        };
+    }
+
+    public static Specification<User> hasStatus(UserStatus status) {
+        return (root, query, cb) -> {
+            if (status == null) {
+                return null;
+            }
+            return cb.equal(root.get(User_.status), status);
+        };
+    }
+
+    public static Specification<User> hasFirstName(String name) {
+        return (root, query, cb) -> {
+            if (name == null || name.isBlank()) {
+                return null;
+            }
+            Join<User, Person> personJoin = root.join(User_.person, JoinType.INNER);
+            return cb.equal(personJoin.get(Person_.firstName), name);
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- generate JPA static metamodels via `hibernate-jpamodelgen`
- add specifications for email, status and person first name
- expose `/api/users/search` endpoint using dynamic filters wrapped in `ApiResponse`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6893f64b246c8330aac83983ac897871