### PR TITLE
feat: add jwt auth to swagger

### DIFF
--- a/src/main/java/me/quadradev/application/core/controller/UserController.java
+++ b/src/main/java/me/quadradev/application/core/controller/UserController.java
@@ -8,9 +8,11 @@ import me.quadradev.common.util.ApiResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 
 import java.util.List;
 
+@SecurityRequirement(name = "bearerAuth")
 @RestController
 @RequestMapping("/api/users")
 @RequiredArgsConstructor

--- a/src/main/java/me/quadradev/config/SwaggerConfig.java
+++ b/src/main/java/me/quadradev/config/SwaggerConfig.java
@@ -2,6 +2,9 @@ package me.quadradev.config;
 
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -10,6 +13,13 @@ public class SwaggerConfig {
 
     @Bean
     public OpenAPI api() {
-        return new OpenAPI().info(new Info().title("API").version("1.0"));
+        return new OpenAPI()
+                .addSecurityItem(new SecurityRequirement().addList("bearerAuth"))
+                .components(new Components().addSecuritySchemes("bearerAuth",
+                        new SecurityScheme()
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")))
+                .info(new Info().title("API").version("1.0"));
     }
 }


### PR DESCRIPTION
## Summary
- add security scheme for JWT and configure swagger UI
- mark user endpoints as secured by bearer auth

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6895373b3d48833096d0541dc278fb60