### PR TITLE
feat(auth): validate user on refresh

### DIFF
--- a/src/main/java/me/quadradev/application/auth/AuthController.java
+++ b/src/main/java/me/quadradev/application/auth/AuthController.java
@@ -24,9 +24,10 @@ public class AuthController {
 
     @PostMapping("/refresh")
     public ResponseEntity<Void> refresh(@RequestHeader("Refresh-Token") String refreshToken) {
-        String newAccessToken = authService.refreshAccessToken(refreshToken);
+        AuthTokens tokens = authService.refreshAccessToken(refreshToken);
         return ResponseEntity.ok()
-                .header(HttpHeaders.AUTHORIZATION, "Bearer " + newAccessToken)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + tokens.accessToken())
+                .header("Refresh-Token", tokens.refreshToken())
                 .build();
     }
 }


### PR DESCRIPTION
## Summary
- ensure refresh flow validates token signature/expiration and user status before issuing new tokens
- return both access and refresh tokens from `/api/auth/refresh`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6895500542d483308f88d41a042eec75