### PR TITLE
docs: add architecture and security documentation

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,16 @@
+# Arquitectura
+
+La aplicación sigue un enfoque de **arquitectura hexagonal**. Esta separación permite aislar la lógica de negocio de los detalles de infraestructura y facilita las pruebas y el mantenimiento.
+
+## Flujo
+1. Un cliente realiza una petición HTTP a un **controlador**.
+2. El controlador actúa como adaptador de entrada y delega la operación a un **servicio**.
+3. El servicio ejecuta el caso de uso en la capa de aplicación y se comunica con el **dominio**.
+4. Cuando se necesitan recursos externos, se utilizan adaptadores de salida como **repositorios** o **clientes**.
+5. La respuesta retorna por el mismo camino hasta el cliente.
+
+## Funcionamiento general
+- `Application` es el punto de entrada que arranca el contenedor de Spring.
+- `UserController` expone los endpoints REST.
+- `UserService` contiene la lógica de negocio.
+- `UserRepository` gestiona la persistencia de datos.

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,16 @@
+# Seguridad
+
+La aplicación utiliza **Spring Security** con autenticación basada en **JWT** para proteger los endpoints.
+
+## Componentes principales
+- `SecurityConfig` define la cadena de filtros, deshabilita CSRF, establece sesiones *stateless* y configura los puntos públicos.
+- `JwtFilter` intercepta cada petición y valida el token presente en el encabezado `Authorization`.
+- `JwtProvider` genera y verifica los tokens de acceso y de refresco.
+- `AuthService` gestiona el proceso de inicio de sesión y la renovación de tokens.
+- Las contraseñas de los usuarios se almacenan mediante `BCryptPasswordEncoder`.
+
+## Flujo de autenticación
+1. El usuario envía sus credenciales a `/api/auth/login`.
+2. `AuthService` verifica la información y retorna un par de tokens.
+3. El cliente envía el token de acceso en el encabezado `Authorization: Bearer <token>`.
+4. `JwtFilter` valida el token y, si es correcto, establece la autenticación en el contexto de seguridad.


### PR DESCRIPTION
## Summary
- Document overall architecture and request flow
- Describe security components and JWT-based authentication

## Testing
- `mvn test` *(fails: Non-resolvable parent POM for me.quadradev:api:0.0.1-SNAPSHOT: The following artifacts could not be resolved: org.springframework.boot:spring-boot-starter-parent:pom:3.3.2 (absent): Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.3.2 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6896251dbfd08330a6241c0d00f4cd8d