### PR TITLE
Rename application to api-generic and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# API Payments
+# API Generic
 
-[Arquitectura](docs/architecture.md) | [Seguridad](docs/security.md)
+[Arquitectura](docs/architecture.md) | [Seguridad](docs/security.md) | [Licencia](LICENSE)
 
 ## Configuración del entorno
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,9 +9,9 @@
         <relativePath/>
     </parent>
     <groupId>me.quadradev</groupId>
-    <artifactId>api</artifactId>
+    <artifactId>api-generic</artifactId>
     <version>0.0.1-SNAPSHOT</version>
-    <name>api</name>
+    <name>api-generic</name>
     <description>API base project</description>
     <properties>
         <java.version>17</java.version>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 spring.config.import=optional:file:.env[.properties]
 
-spring.application.name=api
+spring.application.name=api-generic
 
 spring.datasource.url=jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}
 spring.datasource.username=${DB_USERNAME}


### PR DESCRIPTION
## Summary
- Rename application to `api-generic` in Maven config and properties
- Update README with new project name and documentation links

## Testing
- `./mvnw -q test` *(failed: wget: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.11/apache-maven-3.9.11-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_68962b54c18c83309e271ab7f5b42a5f