### PR TITLE
Add validation annotations to requests and controllers

### DIFF
--- a/src/main/java/me/quadradev/application/core/controller/RoleController.java
+++ b/src/main/java/me/quadradev/application/core/controller/RoleController.java
@@ -1,5 +1,6 @@
 package me.quadradev.application.core.controller;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import me.quadradev.application.core.dto.RoleDto;
 import me.quadradev.application.core.dto.RoleRequest;
@@ -9,6 +10,7 @@ import me.quadradev.application.core.model.User;
 import me.quadradev.application.core.service.RoleService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -19,18 +21,19 @@ import java.util.stream.Collectors;
 @RestController
 @RequestMapping("/api/roles")
 @RequiredArgsConstructor
+@Validated
 public class RoleController {
 
     private final RoleService roleService;
 
     @PostMapping
-    public ResponseEntity<RoleDto> create(@RequestBody RoleRequest request) {
+    public ResponseEntity<RoleDto> create(@RequestBody @Valid RoleRequest request) {
         Role created = roleService.createRole(request.toEntity());
         return ResponseEntity.status(HttpStatus.CREATED).body(RoleDto.fromEntity(created));
     }
 
     @PostMapping("/{userId}/assign")
-    public ResponseEntity<UserDto> assignRoles(@PathVariable Long userId, @RequestBody Set<String> roles) {
+    public ResponseEntity<UserDto> assignRoles(@PathVariable Long userId, @RequestBody @Valid Set<String> roles) {
         User user = roleService.assignRolesToUser(userId, roles);
         return ResponseEntity.ok(UserDto.fromEntity(user));
     }

--- a/src/main/java/me/quadradev/application/core/controller/UserController.java
+++ b/src/main/java/me/quadradev/application/core/controller/UserController.java
@@ -1,5 +1,6 @@
 package me.quadradev.application.core.controller;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import me.quadradev.application.core.dto.UserDto;
 import me.quadradev.application.core.dto.UserRequest;
@@ -9,14 +10,15 @@ import me.quadradev.application.core.service.UserService;
 import me.quadradev.common.util.ApiResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 
 import java.util.List;
 
 @RestController
 @RequestMapping("/api/users")
 @RequiredArgsConstructor
+@Validated
 public class UserController {
 
     private final UserService userService;
@@ -34,13 +36,13 @@ public class UserController {
     }
 
     @PostMapping
-    public ResponseEntity<UserDto> create(@RequestBody UserRequest request) {
+    public ResponseEntity<UserDto> create(@RequestBody @Valid UserRequest request) {
         User created = userService.createUser(request.toEntity());
         return ResponseEntity.status(HttpStatus.CREATED).body(UserDto.fromEntity(created));
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<UserDto> update(@PathVariable Long id, @RequestBody UserRequest request) {
+    public ResponseEntity<UserDto> update(@PathVariable Long id, @RequestBody @Valid UserRequest request) {
         User updated = userService.updateUser(id, request.toEntity());
         return ResponseEntity.ok(UserDto.fromEntity(updated));
     }

--- a/src/main/java/me/quadradev/application/core/dto/RoleRequest.java
+++ b/src/main/java/me/quadradev/application/core/dto/RoleRequest.java
@@ -1,8 +1,9 @@
 package me.quadradev.application.core.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import me.quadradev.application.core.model.Role;
 
-public record RoleRequest(String name) {
+public record RoleRequest(@NotBlank String name) {
     public Role toEntity() {
         return Role.builder().name(name).build();
     }

--- a/src/main/java/me/quadradev/application/core/dto/UserRequest.java
+++ b/src/main/java/me/quadradev/application/core/dto/UserRequest.java
@@ -1,17 +1,20 @@
 package me.quadradev.application.core.dto;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import me.quadradev.application.core.model.Person;
 import me.quadradev.application.core.model.User;
 import me.quadradev.application.core.model.UserStatus;
 
 public record UserRequest(
-        String email,
-        String password,
-        String firstName,
+        @NotBlank @Email String email,
+        @NotBlank String password,
+        @NotBlank String firstName,
         String middleName,
-        String lastName,
+        @NotBlank String lastName,
         String secondLastName,
-        UserStatus status
+        @NotNull UserStatus status
 ) {
     public User toEntity() {
         Person person = Person.builder()


### PR DESCRIPTION
## Summary
- add bean validation constraints to `UserRequest` and `RoleRequest`
- validate request payloads in `UserController` and `RoleController`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6896a0a5faa88330b3cfde1db68695bc