### PR TITLE
Validate role names on assignment

### DIFF
--- a/src/main/java/me/quadradev/application/core/controller/RoleController.java
+++ b/src/main/java/me/quadradev/application/core/controller/RoleController.java
@@ -1,6 +1,7 @@
 package me.quadradev.application.core.controller;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import me.quadradev.application.core.dto.RoleDto;
 import me.quadradev.application.core.dto.RoleRequest;
@@ -33,7 +34,7 @@ public class RoleController {
     }
 
     @PostMapping("/{userId}/assign")
-    public ResponseEntity<UserDto> assignRoles(@PathVariable Long userId, @RequestBody @Valid Set<String> roles) {
+    public ResponseEntity<UserDto> assignRoles(@PathVariable Long userId, @RequestBody Set<@NotBlank String> roles) {
         User user = roleService.assignRolesToUser(userId, roles);
         return ResponseEntity.ok(UserDto.fromEntity(user));
     }

--- a/src/test/java/me/quadradev/application/core/controller/RoleControllerValidationTest.java
+++ b/src/test/java/me/quadradev/application/core/controller/RoleControllerValidationTest.java
@@ -1,0 +1,34 @@
+package me.quadradev.application.core.controller;
+
+import me.quadradev.application.core.service.RoleService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(RoleController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class RoleControllerValidationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private RoleService roleService;
+
+    @Test
+    void assignRoles_shouldReturnBadRequest_whenRoleNameIsBlank() throws Exception {
+        String body = "[\"ROLE_USER\", \"\"]";
+
+        mockMvc.perform(post("/api/roles/{userId}/assign", 1L)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
+                .andExpect(status().isBadRequest());
+    }
+}


### PR DESCRIPTION
## Summary
- ensure role names in assignment are not blank by annotating request body elements
- test that assigning blank role names returns bad request

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6897a45c076c8330b4fc889a24cfeb24