### PR TITLE
feat: make CORS origins configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,4 @@ MAIL_USERNAME=your_email@example.com
 MAIL_PASSWORD=your_email_password
 JWT_SECRET=changeme
 DEV_MODE=true
+CORS_ALLOWED_ORIGINS=http://localhost:3000

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ El archivo `application.properties` toma los datos de conexión a la base de dat
 desde las variables definidas en `.env` (`DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USERNAME`
 y `DB_PASSWORD`).
 
+Para restringir el acceso CORS de la API, define la variable `CORS_ALLOWED_ORIGINS`
+con una lista de orígenes separados por comas que podrán consumir los servicios.
+
 ## Licencia
 
 Este proyecto se distribuye bajo la licencia [MIT](LICENSE).

--- a/src/main/java/me/quadradev/config/CorsConfig.java
+++ b/src/main/java/me/quadradev/config/CorsConfig.java
@@ -1,0 +1,28 @@
+package me.quadradev.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig {
+
+    @Value("${cors.allowed-origins}")
+    private String[] allowedOrigins;
+
+    @Bean
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void addCorsMappings(CorsRegistry registry) {
+                registry.addMapping("/**")
+                        .allowedOrigins(allowedOrigins)
+                        .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                        .allowedHeaders("*")
+                        .allowCredentials(true);
+            }
+        };
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,4 +15,6 @@ jwt.secret=${JWT_SECRET}
 jwt.access-token-expiration-ms=900000
 jwt.refresh-token-expiration-ms=604800000
 
+cors.allowed-origins=${CORS_ALLOWED_ORIGINS:http://localhost:3000}
+
 DEV_MODE=${DEV_MODE}


### PR DESCRIPTION
## Summary
- allow configuring CORS origins via the `CORS_ALLOWED_ORIGINS` env var
- document `CORS_ALLOWED_ORIGINS` and add default entry to `.env.example`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6897a4a905808330ad09ac70ef1425db