### PR TITLE
feat: secure password management

### DIFF
--- a/src/main/java/me/quadradev/application/auth/LoginRequest.java
+++ b/src/main/java/me/quadradev/application/auth/LoginRequest.java
@@ -1,9 +1,10 @@
 package me.quadradev.application.auth;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 
 public record LoginRequest(
         @NotBlank @Email String email,
-        @NotBlank String password
+        @NotBlank @JsonProperty(access = JsonProperty.Access.WRITE_ONLY) String password
 ) {}

--- a/src/main/java/me/quadradev/application/core/controller/UserController.java
+++ b/src/main/java/me/quadradev/application/core/controller/UserController.java
@@ -4,6 +4,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import me.quadradev.application.core.dto.UserDto;
 import me.quadradev.application.core.dto.UserRequest;
+import me.quadradev.application.core.dto.ChangePasswordRequest;
 import me.quadradev.application.core.model.User;
 import me.quadradev.application.core.model.UserStatus;
 import me.quadradev.application.core.service.UserService;
@@ -45,6 +46,12 @@ public class UserController {
     public ResponseEntity<UserDto> update(@PathVariable Long id, @RequestBody @Valid UserRequest request) {
         User updated = userService.updateUser(id, request.toEntity());
         return ResponseEntity.ok(UserDto.fromEntity(updated));
+    }
+
+    @PutMapping("/{id}/password")
+    public ResponseEntity<Void> changePassword(@PathVariable Long id, @RequestBody @Valid ChangePasswordRequest request) {
+        userService.changePassword(id, request.currentPassword(), request.newPassword());
+        return ResponseEntity.noContent().build();
     }
 
     @GetMapping("/search")

--- a/src/main/java/me/quadradev/application/core/dto/ChangePasswordRequest.java
+++ b/src/main/java/me/quadradev/application/core/dto/ChangePasswordRequest.java
@@ -1,0 +1,9 @@
+package me.quadradev.application.core.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+
+public record ChangePasswordRequest(
+        @NotBlank @JsonProperty(access = JsonProperty.Access.WRITE_ONLY) String currentPassword,
+        @NotBlank @JsonProperty(access = JsonProperty.Access.WRITE_ONLY) String newPassword
+) {}

--- a/src/main/java/me/quadradev/application/core/dto/UserRequest.java
+++ b/src/main/java/me/quadradev/application/core/dto/UserRequest.java
@@ -1,5 +1,6 @@
 package me.quadradev.application.core.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -9,7 +10,7 @@ import me.quadradev.application.core.model.UserStatus;
 
 public record UserRequest(
         @NotBlank @Email String email,
-        @NotBlank String password,
+        @NotBlank @JsonProperty(access = JsonProperty.Access.WRITE_ONLY) String password,
         @NotBlank String firstName,
         String middleName,
         @NotBlank String lastName,

--- a/src/main/java/me/quadradev/application/core/service/UserService.java
+++ b/src/main/java/me/quadradev/application/core/service/UserService.java
@@ -72,10 +72,6 @@ public class UserService {
             existingUser.setEmail(updatedUser.getEmail());
         }
 
-        if (updatedUser.getPassword() != null && !updatedUser.getPassword().isBlank()) {
-            existingUser.setPassword(passwordEncoder.encode(updatedUser.getPassword()));
-        }
-
         if (updatedUser.getPerson() != null) {
             Person existingPerson = existingUser.getPerson();
             if (existingPerson == null) {
@@ -102,5 +98,16 @@ public class UserService {
         }
 
         return userRepository.save(existingUser);
+    }
+
+    @Transactional
+    public void changePassword(Long id, String currentPassword, String newPassword) {
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new ApiException("User not found", HttpStatus.NOT_FOUND));
+        if (!passwordEncoder.matches(currentPassword, user.getPassword())) {
+            throw new ApiException("Current password is incorrect", HttpStatus.UNAUTHORIZED);
+        }
+        user.setPassword(passwordEncoder.encode(newPassword));
+        userRepository.save(user);
     }
 }


### PR DESCRIPTION
## Summary
- mark password fields as write-only in request DTOs
- add dedicated endpoint to change user passwords
- encode passwords with BCrypt on create and password change

## Testing
- `./mvnw -q test` *(fails: wget: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.11/apache-maven-3.9.11-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_689a38b09b648330b6c42a880b329949