### PR TITLE
feat: add consistent error responses

### DIFF
--- a/src/main/java/me/quadradev/common/exception/ErrorResponse.java
+++ b/src/main/java/me/quadradev/common/exception/ErrorResponse.java
@@ -1,0 +1,14 @@
+package me.quadradev.common.exception;
+
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class ErrorResponse {
+    int code;
+    String message;
+    Object detail;
+    String traceId;
+}
+

--- a/src/main/java/me/quadradev/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/me/quadradev/common/exception/GlobalExceptionHandler.java
@@ -1,21 +1,42 @@
 package me.quadradev.common.exception;
 
+import java.util.UUID;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-import me.quadradev.common.util.ApiResponse;
-
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+    private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
 
     @ExceptionHandler(ApiException.class)
-    public ResponseEntity<ApiResponse<?>> handleApiException(ApiException ex) {
-        ApiResponse<?> body = ApiResponse.error(
-                ex.getStatus().value(),
-                ex.getMessage(),
-                null
-        );
+    public ResponseEntity<ErrorResponse> handleApiException(ApiException ex) {
+        String traceId = UUID.randomUUID().toString();
+        log.error("API exception traceId={}", traceId, ex);
+        ErrorResponse body = ErrorResponse.builder()
+                .code(ex.getStatus().value())
+                .message(ex.getMessage())
+                .detail(null)
+                .traceId(traceId)
+                .build();
         return ResponseEntity.status(ex.getStatus()).body(body);
     }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(Exception ex) {
+        String traceId = UUID.randomUUID().toString();
+        log.error("Unexpected exception traceId={}", traceId, ex);
+        ErrorResponse body = ErrorResponse.builder()
+                .code(HttpStatus.INTERNAL_SERVER_ERROR.value())
+                .message("Internal server error")
+                .detail(ex.getMessage())
+                .traceId(traceId)
+                .build();
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(body);
+    }
 }
+


### PR DESCRIPTION
## Summary
- add `ErrorResponse` record for consistent error format
- enhance global exception handler to return `ErrorResponse` with trace IDs

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.3.2 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689a6d4462c8833097af986bdbe00978