### PR TITLE
Add centralized MapStruct configuration

### DIFF
--- a/src/main/java/me/quadradev/application/core/mapper/MapStructConfig.java
+++ b/src/main/java/me/quadradev/application/core/mapper/MapStructConfig.java
@@ -1,0 +1,16 @@
+package me.quadradev.application.core.mapper;
+
+import org.mapstruct.InjectionStrategy;
+import org.mapstruct.MapperConfig;
+import org.mapstruct.NullValuePropertyMappingStrategy;
+import org.mapstruct.ReportingPolicy;
+
+@MapperConfig(
+    componentModel = "spring",
+    unmappedTargetPolicy = ReportingPolicy.ERROR,
+    nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE,
+    injectionStrategy = InjectionStrategy.CONSTRUCTOR
+)
+public interface MapStructConfig {
+}
+

--- a/src/main/java/me/quadradev/application/core/mapper/RoleMapper.java
+++ b/src/main/java/me/quadradev/application/core/mapper/RoleMapper.java
@@ -5,7 +5,7 @@ import me.quadradev.application.core.dto.RoleRequest;
 import me.quadradev.application.core.model.Role;
 import org.mapstruct.Mapper;
 
-@Mapper(componentModel = "spring")
+@Mapper(config = MapStructConfig.class)
 public interface RoleMapper {
     Role toEntity(RoleRequest request);
     RoleDto toDto(Role role);

--- a/src/main/java/me/quadradev/application/core/mapper/UserMapper.java
+++ b/src/main/java/me/quadradev/application/core/mapper/UserMapper.java
@@ -10,7 +10,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-@Mapper(componentModel = "spring")
+@Mapper(config = MapStructConfig.class)
 public interface UserMapper {
 
     @Mapping(target = "firstName", source = "person.firstName")
@@ -30,7 +30,6 @@ public interface UserMapper {
     @Mapping(target = "id", ignore = true)
     User toEntity(UserRequest request);
 
-    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
     @Mapping(target = "person.firstName", source = "firstName")
     @Mapping(target = "person.middleName", source = "middleName")
     @Mapping(target = "person.lastName", source = "lastName")


### PR DESCRIPTION
## Summary
- introduce `MapStructConfig` to set common mapping strategy
- apply shared config to existing mappers

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.3.2 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689a6f1978a08330bfe98334d43ff80e