### PR TITLE
Handle common validation and security exceptions

### DIFF
--- a/src/main/java/me/quadradev/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/me/quadradev/common/exception/GlobalExceptionHandler.java
@@ -1,11 +1,18 @@
 package me.quadradev.common.exception;
 
+import java.util.List;
 import java.util.UUID;
 
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.validation.ConstraintViolationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -24,6 +31,90 @@ public class GlobalExceptionHandler {
                 .traceId(traceId)
                 .build();
         return ResponseEntity.status(ex.getStatus()).body(body);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValid(MethodArgumentNotValidException ex) {
+        String traceId = UUID.randomUUID().toString();
+        log.warn("Method argument not valid traceId={}", traceId, ex);
+        List<String> details = ex.getBindingResult().getFieldErrors().stream()
+                .map(err -> err.getField() + ": " + err.getDefaultMessage())
+                .toList();
+        ErrorResponse body = ErrorResponse.builder()
+                .code(HttpStatus.BAD_REQUEST.value())
+                .message("Validation failed")
+                .detail(details)
+                .traceId(traceId)
+                .build();
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body);
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ErrorResponse> handleConstraintViolation(ConstraintViolationException ex) {
+        String traceId = UUID.randomUUID().toString();
+        log.warn("Constraint violation traceId={}", traceId, ex);
+        List<String> details = ex.getConstraintViolations().stream()
+                .map(cv -> cv.getPropertyPath() + ": " + cv.getMessage())
+                .toList();
+        ErrorResponse body = ErrorResponse.builder()
+                .code(HttpStatus.BAD_REQUEST.value())
+                .message("Validation failed")
+                .detail(details)
+                .traceId(traceId)
+                .build();
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body);
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<ErrorResponse> handleAccessDenied(AccessDeniedException ex) {
+        String traceId = UUID.randomUUID().toString();
+        log.warn("Access denied traceId={}", traceId, ex);
+        ErrorResponse body = ErrorResponse.builder()
+                .code(HttpStatus.FORBIDDEN.value())
+                .message("Access denied")
+                .detail(null)
+                .traceId(traceId)
+                .build();
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(body);
+    }
+
+    @ExceptionHandler(AuthenticationException.class)
+    public ResponseEntity<ErrorResponse> handleAuthentication(AuthenticationException ex) {
+        String traceId = UUID.randomUUID().toString();
+        log.warn("Authentication failed traceId={}", traceId, ex);
+        ErrorResponse body = ErrorResponse.builder()
+                .code(HttpStatus.UNAUTHORIZED.value())
+                .message("Unauthorized")
+                .detail(null)
+                .traceId(traceId)
+                .build();
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(body);
+    }
+
+    @ExceptionHandler(EntityNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleEntityNotFound(EntityNotFoundException ex) {
+        String traceId = UUID.randomUUID().toString();
+        log.warn("Entity not found traceId={}", traceId, ex);
+        ErrorResponse body = ErrorResponse.builder()
+                .code(HttpStatus.NOT_FOUND.value())
+                .message(ex.getMessage())
+                .detail(null)
+                .traceId(traceId)
+                .build();
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(body);
+    }
+
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<ErrorResponse> handleDataIntegrityViolation(DataIntegrityViolationException ex) {
+        String traceId = UUID.randomUUID().toString();
+        log.error("Data integrity violation traceId={}", traceId, ex);
+        ErrorResponse body = ErrorResponse.builder()
+                .code(HttpStatus.CONFLICT.value())
+                .message("Data integrity violation")
+                .detail(ex.getMessage())
+                .traceId(traceId)
+                .build();
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(body);
     }
 
     @ExceptionHandler(Exception.class)


### PR DESCRIPTION
## Summary
- add explicit handlers for validation failures using ErrorResponse
- unify 401/403 security errors
- map persistence errors to consistent 404/409 responses

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689a74337dc4833096f9a4326f04b25f