### PR TITLE
Add optimistic locking and unique index conflict handling

### DIFF
--- a/src/main/java/me/quadradev/application/core/model/Person.java
+++ b/src/main/java/me/quadradev/application/core/model/Person.java
@@ -20,6 +20,9 @@ public class Person {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Version
+    private Long version;
+
     private String firstName;
 
     @Column(nullable = true)

--- a/src/main/java/me/quadradev/application/core/model/Role.java
+++ b/src/main/java/me/quadradev/application/core/model/Role.java
@@ -6,7 +6,9 @@ import lombok.*;
 import java.util.HashSet;
 import java.util.Set;
 @Entity
-@Table(name = "core_roles")
+@Table(name = "core_roles", indexes = {
+        @Index(name = "idx_core_roles_name", columnList = "name", unique = true)
+})
 @Getter
 @Setter
 @NoArgsConstructor
@@ -17,6 +19,9 @@ public class Role {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Version
+    private Long version;
 
     @Column(unique = true, nullable = false)
     private String name;

--- a/src/main/java/me/quadradev/application/core/model/User.java
+++ b/src/main/java/me/quadradev/application/core/model/User.java
@@ -16,7 +16,9 @@ import java.util.HashSet;
 import java.util.Set;
 
 @Entity
-@Table(name = "core_users")
+@Table(name = "core_users", indexes = {
+        @Index(name = "idx_core_users_email", columnList = "email", unique = true)
+})
 @EntityListeners(AuditingEntityListener.class)
 @Getter
 @Setter
@@ -28,6 +30,9 @@ public class User {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Version
+    private Long version;
 
     @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     private String password;

--- a/src/main/java/me/quadradev/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/me/quadradev/common/exception/GlobalExceptionHandler.java
@@ -4,12 +4,14 @@ import java.util.List;
 import java.util.UUID;
 
 import jakarta.persistence.EntityNotFoundException;
+import jakarta.persistence.OptimisticLockException;
 import jakarta.validation.ConstraintViolationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -111,6 +113,19 @@ public class GlobalExceptionHandler {
         ErrorResponse body = ErrorResponse.builder()
                 .code(HttpStatus.CONFLICT.value())
                 .message("Data integrity violation")
+                .detail(ex.getMessage())
+                .traceId(traceId)
+                .build();
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(body);
+    }
+
+    @ExceptionHandler({OptimisticLockException.class, ObjectOptimisticLockingFailureException.class})
+    public ResponseEntity<ErrorResponse> handleOptimisticLock(Exception ex) {
+        String traceId = UUID.randomUUID().toString();
+        log.warn("Optimistic locking failure traceId={}", traceId, ex);
+        ErrorResponse body = ErrorResponse.builder()
+                .code(HttpStatus.CONFLICT.value())
+                .message("Resource version conflict")
                 .detail(ex.getMessage())
                 .traceId(traceId)
                 .build();


### PR DESCRIPTION
## Summary
- Add @Version fields to core entities for optimistic locking
- Define unique indexes for user email and role name
- Handle optimistic locking failures with HTTP 409

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689a7cf50fbc83309c417bee0fadf9e6