### PR TITLE
Implement RBAC menu system with caching

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,14 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-cache</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-redis</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>

--- a/src/main/java/me/quadradev/Application.java
+++ b/src/main/java/me/quadradev/Application.java
@@ -2,8 +2,10 @@ package me.quadradev;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 
 @SpringBootApplication
+@EnableCaching
 public class Application {
 
     public static void main(String[] args) {

--- a/src/main/java/me/quadradev/application/core/controller/MenuController.java
+++ b/src/main/java/me/quadradev/application/core/controller/MenuController.java
@@ -1,0 +1,25 @@
+package me.quadradev.application.core.controller;
+
+import lombok.RequiredArgsConstructor;
+import me.quadradev.application.core.dto.MenuNodeDto;
+import me.quadradev.application.core.service.MenuService;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/menus")
+@RequiredArgsConstructor
+public class MenuController {
+
+    private final MenuService menuService;
+
+    @GetMapping("/tree")
+    public List<MenuNodeDto> getMenuTree(Authentication authentication) {
+        String email = (String) authentication.getPrincipal();
+        return menuService.getMenuTreeForUser(email);
+    }
+}

--- a/src/main/java/me/quadradev/application/core/controller/RoleController.java
+++ b/src/main/java/me/quadradev/application/core/controller/RoleController.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import me.quadradev.application.core.dto.RoleDto;
 import me.quadradev.application.core.dto.RoleRequest;
 import me.quadradev.application.core.dto.UserDto;
+import me.quadradev.application.core.dto.RolePermissionRequest;
 import me.quadradev.application.core.service.RoleService;
 import me.quadradev.common.util.PageResponse;
 import org.springframework.data.domain.Pageable;
@@ -45,5 +46,12 @@ public class RoleController {
     @GetMapping("/user/{userId}")
     public Set<RoleDto> getRolesByUser(@PathVariable Long userId) {
         return roleService.getRolesByUser(userId);
+    }
+
+    @PostMapping("/{roleId}/permissions")
+    public ResponseEntity<Void> updatePermissions(@PathVariable Long roleId,
+                                                  @RequestBody @Valid RolePermissionRequest request) {
+        roleService.updateMenuPermissions(roleId, request.menuId(), request.actions());
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/me/quadradev/application/core/dto/MenuNodeDto.java
+++ b/src/main/java/me/quadradev/application/core/dto/MenuNodeDto.java
@@ -1,0 +1,9 @@
+package me.quadradev.application.core.dto;
+
+import me.quadradev.application.core.model.MenuAction;
+
+import java.util.List;
+import java.util.Set;
+
+public record MenuNodeDto(Long id, String code, String name, Set<MenuAction> actions, List<MenuNodeDto> children) {
+}

--- a/src/main/java/me/quadradev/application/core/dto/RolePermissionRequest.java
+++ b/src/main/java/me/quadradev/application/core/dto/RolePermissionRequest.java
@@ -1,0 +1,8 @@
+package me.quadradev.application.core.dto;
+
+import me.quadradev.application.core.model.MenuAction;
+
+import java.util.Set;
+
+public record RolePermissionRequest(Long menuId, Set<MenuAction> actions) {
+}

--- a/src/main/java/me/quadradev/application/core/model/Menu.java
+++ b/src/main/java/me/quadradev/application/core/model/Menu.java
@@ -1,0 +1,44 @@
+package me.quadradev.application.core.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+@Table(name = "core_menus", indexes = {
+        @Index(name = "idx_core_menu_code", columnList = "code", unique = true)
+})
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Menu {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Version
+    private Long version;
+
+    @Column(nullable = false, unique = true)
+    private String code;
+
+    @Column(nullable = false)
+    private String name;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id")
+    private Menu parent;
+
+    @Builder.Default
+    @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<Menu> children = new HashSet<>();
+
+    @Builder.Default
+    @OneToMany(mappedBy = "menu", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<RoleMenuPermission> rolePermissions = new HashSet<>();
+}

--- a/src/main/java/me/quadradev/application/core/model/MenuAction.java
+++ b/src/main/java/me/quadradev/application/core/model/MenuAction.java
@@ -1,0 +1,35 @@
+package me.quadradev.application.core.model;
+
+import lombok.Getter;
+
+/**
+ * Bitmask based permissions for menus.
+ */
+@Getter
+public enum MenuAction {
+    VIEW(1 << 0),
+    CREATE(1 << 1),
+    UPDATE(1 << 2),
+    DELETE(1 << 3),
+    EXPORT(1 << 4),
+    APPROVE(1 << 5),
+    MANAGE(1 << 6);
+
+    private final int mask;
+
+    MenuAction(int mask) {
+        this.mask = mask;
+    }
+
+    public static int toMask(Iterable<MenuAction> actions) {
+        int result = 0;
+        for (MenuAction action : actions) {
+            result |= action.getMask();
+        }
+        return result;
+    }
+
+    public static boolean hasAction(int mask, MenuAction action) {
+        return (mask & action.getMask()) != 0;
+    }
+}

--- a/src/main/java/me/quadradev/application/core/model/Role.java
+++ b/src/main/java/me/quadradev/application/core/model/Role.java
@@ -29,4 +29,8 @@ public class Role {
     @Builder.Default
     @ManyToMany(mappedBy = "roles", fetch = FetchType.LAZY)
     private Set<User> users = new HashSet<>();
+
+    @Builder.Default
+    @OneToMany(mappedBy = "role", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<RoleMenuPermission> menuPermissions = new HashSet<>();
 }

--- a/src/main/java/me/quadradev/application/core/model/RoleMenuPermission.java
+++ b/src/main/java/me/quadradev/application/core/model/RoleMenuPermission.java
@@ -1,0 +1,33 @@
+package me.quadradev.application.core.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "core_role_menu_permissions",
+        uniqueConstraints = @UniqueConstraint(name = "uk_role_menu", columnNames = {"role_id", "menu_id"}))
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RoleMenuPermission {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "role_id", nullable = false)
+    private Role role;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "menu_id", nullable = false)
+    private Menu menu;
+
+    /**
+     * Bitmask of {@link MenuAction} permissions.
+     */
+    @Column(nullable = false)
+    private int permissions;
+}

--- a/src/main/java/me/quadradev/application/core/repository/MenuRepository.java
+++ b/src/main/java/me/quadradev/application/core/repository/MenuRepository.java
@@ -1,0 +1,7 @@
+package me.quadradev.application.core.repository;
+
+import me.quadradev.application.core.model.Menu;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MenuRepository extends JpaRepository<Menu, Long> {
+}

--- a/src/main/java/me/quadradev/application/core/repository/RoleMenuPermissionRepository.java
+++ b/src/main/java/me/quadradev/application/core/repository/RoleMenuPermissionRepository.java
@@ -1,0 +1,12 @@
+package me.quadradev.application.core.repository;
+
+import me.quadradev.application.core.model.Menu;
+import me.quadradev.application.core.model.Role;
+import me.quadradev.application.core.model.RoleMenuPermission;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RoleMenuPermissionRepository extends JpaRepository<RoleMenuPermission, Long> {
+    Optional<RoleMenuPermission> findByRoleAndMenu(Role role, Menu menu);
+}

--- a/src/main/java/me/quadradev/application/core/service/MenuService.java
+++ b/src/main/java/me/quadradev/application/core/service/MenuService.java
@@ -1,0 +1,52 @@
+package me.quadradev.application.core.service;
+
+import lombok.RequiredArgsConstructor;
+import me.quadradev.application.core.dto.MenuNodeDto;
+import me.quadradev.application.core.model.*;
+import me.quadradev.application.core.repository.MenuRepository;
+import me.quadradev.application.core.repository.UserRepository;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class MenuService {
+
+    private final UserRepository userRepository;
+    private final MenuRepository menuRepository;
+
+    @Transactional(readOnly = true)
+    @Cacheable(value = "menuTree", key = "#email")
+    public List<MenuNodeDto> getMenuTreeForUser(String email) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+        Map<Menu, Integer> permissions = new HashMap<>();
+        for (Role role : user.getRoles()) {
+            for (RoleMenuPermission perm : role.getMenuPermissions()) {
+                permissions.merge(perm.getMenu(), perm.getPermissions(), (a, b) -> a | b);
+            }
+        }
+        // build tree starting from menus with no parent
+        List<Menu> roots = permissions.keySet().stream()
+                .filter(m -> m.getParent() == null)
+                .sorted(Comparator.comparing(Menu::getId))
+                .collect(Collectors.toList());
+        return roots.stream().map(m -> buildNode(m, permissions)).collect(Collectors.toList());
+    }
+
+    private MenuNodeDto buildNode(Menu menu, Map<Menu, Integer> permissions) {
+        Set<MenuAction> actions = Arrays.stream(MenuAction.values())
+                .filter(a -> MenuAction.hasAction(permissions.get(menu), a))
+                .collect(Collectors.toCollection(() -> EnumSet.noneOf(MenuAction.class)));
+        List<MenuNodeDto> children = menu.getChildren().stream()
+                .filter(permissions::containsKey)
+                .sorted(Comparator.comparing(Menu::getId))
+                .map(child -> buildNode(child, permissions))
+                .collect(Collectors.toList());
+        return new MenuNodeDto(menu.getId(), menu.getCode(), menu.getName(), actions, children);
+    }
+}


### PR DESCRIPTION
## Summary
- add hierarchical menu entity and bitmask-based actions
- cache user menu tree and evict on role-permission changes
- expose endpoints to fetch menu tree and update role permissions

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689a8254981483309613c7844891cfe8