### PR TITLE
Agregar compose para instancias de base de datos

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: "3.9"
+
+services:
+  db:
+    image: mysql:8.0
+    restart: unless-stopped
+    env_file:
+      - .env
+    environment:
+      MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD}
+      MYSQL_DATABASE: ${DB_NAME}
+      MYSQL_USER: ${DB_USERNAME}
+      MYSQL_PASSWORD: ${DB_PASSWORD}
+    ports:
+      - "${DB_PORT}:3306"
+    volumes:
+      - db-data:/var/lib/mysql
+
+volumes:
+  db-data:


### PR DESCRIPTION
## Resumen
- Añade `docker-compose.yml` para iniciar y gestionar una instancia de MySQL.

## Testing
- `mvn -q test` *(falla: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689cd58ac6a88330aa860c0116b1714f