### PR TITLE
Add standard error responses to Swagger

### DIFF
--- a/src/main/java/me/quadradev/config/SwaggerConfig.java
+++ b/src/main/java/me/quadradev/config/SwaggerConfig.java
@@ -34,8 +34,11 @@ public class SwaggerConfig {
         return openApi -> openApi.getPaths().values().forEach(pathItem ->
                 pathItem.readOperations().forEach(operation -> {
                     ApiResponses responses = operation.getResponses();
-                    responses.addApiResponse("4XX", errorApiResponse("Client error"));
-                    responses.addApiResponse("5XX", errorApiResponse("Server error"));
+                    responses.addApiResponse("400", errorApiResponse("Bad Request"));
+                    responses.addApiResponse("401", errorApiResponse("Unauthorized"));
+                    responses.addApiResponse("403", errorApiResponse("Forbidden"));
+                    responses.addApiResponse("404", errorApiResponse("Not Found"));
+                    responses.addApiResponse("500", errorApiResponse("Internal Server Error"));
                 }));
     }
 


### PR DESCRIPTION
## Summary
- configure swagger to document 400, 401, 403, 404 and 500 error responses for all operations

## Testing
- `./mvnw test` *(fails: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.11/apache-maven-3.9.11-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_689ce41bf0f48330a4e7e5e4d8c93099