### PR TITLE
fix: register ErrorResponse schema and global responses

### DIFF
--- a/src/main/java/me/quadradev/common/exception/ErrorResponse.java
+++ b/src/main/java/me/quadradev/common/exception/ErrorResponse.java
@@ -1,27 +1,23 @@
 package me.quadradev.common.exception;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Builder;
-import lombok.Value;
 
-/**
- * Representation of an error returned by the API.
- */
-@Value
-@Builder
-@Schema(description = "Details of an API error response")
+@Schema(name = "ErrorResponse", description = "Formato estándar de error")
 public class ErrorResponse {
+  @Schema(example = "404") private Integer status;
+  @Schema(example = "Not Found") private String error;
+  @Schema(example = "Recurso no encontrado") private String message;
+  @Schema(example = "/api/users/123") private String path;
+  @Schema(example = "2025-08-13T19:05:00Z") private String timestamp;
 
-    @Schema(description = "HTTP status code of the error")
-    int code;
-
-    @Schema(description = "Human readable error message")
-    String message;
-
-    @Schema(description = "Additional error information")
-    Object detail;
-
-    @Schema(description = "Identifier to trace the request")
-    String traceId;
+  public Integer getStatus() { return status; }
+  public void setStatus(Integer status) { this.status = status; }
+  public String getError() { return error; }
+  public void setError(String error) { this.error = error; }
+  public String getMessage() { return message; }
+  public void setMessage(String message) { this.message = message; }
+  public String getPath() { return path; }
+  public void setPath(String path) { this.path = path; }
+  public String getTimestamp() { return timestamp; }
+  public void setTimestamp(String timestamp) { this.timestamp = timestamp; }
 }
-

--- a/src/main/java/me/quadradev/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/me/quadradev/common/exception/GlobalExceptionHandler.java
@@ -1,10 +1,11 @@
 package me.quadradev.common.exception;
 
-import java.util.List;
-import java.util.UUID;
+import java.time.OffsetDateTime;
+import java.util.stream.Collectors;
 
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.persistence.OptimisticLockException;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -20,129 +21,84 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
-    private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+  private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
 
-    @ExceptionHandler(ApiException.class)
-    public ResponseEntity<ErrorResponse> handleApiException(ApiException ex) {
-        String traceId = UUID.randomUUID().toString();
-        log.error("API exception traceId={}", traceId, ex);
-        ErrorResponse body = ErrorResponse.builder()
-                .code(ex.getStatus().value())
-                .message(ex.getMessage())
-                .detail(null)
-                .traceId(traceId)
-                .build();
-        return ResponseEntity.status(ex.getStatus()).body(body);
-    }
+  @ExceptionHandler(ApiException.class)
+  public ResponseEntity<ErrorResponse> handleApiException(ApiException ex, HttpServletRequest request) {
+    log.error("API exception", ex);
+    ErrorResponse body = buildResponse(ex.getStatus(), ex.getMessage(), request.getRequestURI());
+    return ResponseEntity.status(ex.getStatus()).body(body);
+  }
 
-    @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValid(MethodArgumentNotValidException ex) {
-        String traceId = UUID.randomUUID().toString();
-        log.warn("Method argument not valid traceId={}", traceId, ex);
-        List<String> details = ex.getBindingResult().getFieldErrors().stream()
-                .map(err -> err.getField() + ": " + err.getDefaultMessage())
-                .toList();
-        ErrorResponse body = ErrorResponse.builder()
-                .code(HttpStatus.BAD_REQUEST.value())
-                .message("Validation failed")
-                .detail(details)
-                .traceId(traceId)
-                .build();
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body);
-    }
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public ResponseEntity<ErrorResponse> handleMethodArgumentNotValid(MethodArgumentNotValidException ex, HttpServletRequest request) {
+    log.warn("Method argument not valid", ex);
+    String message = ex.getBindingResult().getFieldErrors().stream()
+        .map(err -> err.getField() + ": " + err.getDefaultMessage())
+        .collect(Collectors.joining(", "));
+    ErrorResponse body = buildResponse(HttpStatus.BAD_REQUEST, message, request.getRequestURI());
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body);
+  }
 
-    @ExceptionHandler(ConstraintViolationException.class)
-    public ResponseEntity<ErrorResponse> handleConstraintViolation(ConstraintViolationException ex) {
-        String traceId = UUID.randomUUID().toString();
-        log.warn("Constraint violation traceId={}", traceId, ex);
-        List<String> details = ex.getConstraintViolations().stream()
-                .map(cv -> cv.getPropertyPath() + ": " + cv.getMessage())
-                .toList();
-        ErrorResponse body = ErrorResponse.builder()
-                .code(HttpStatus.BAD_REQUEST.value())
-                .message("Validation failed")
-                .detail(details)
-                .traceId(traceId)
-                .build();
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body);
-    }
+  @ExceptionHandler(ConstraintViolationException.class)
+  public ResponseEntity<ErrorResponse> handleConstraintViolation(ConstraintViolationException ex, HttpServletRequest request) {
+    log.warn("Constraint violation", ex);
+    String message = ex.getConstraintViolations().stream()
+        .map(cv -> cv.getPropertyPath() + ": " + cv.getMessage())
+        .collect(Collectors.joining(", "));
+    ErrorResponse body = buildResponse(HttpStatus.BAD_REQUEST, message, request.getRequestURI());
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body);
+  }
 
-    @ExceptionHandler(AccessDeniedException.class)
-    public ResponseEntity<ErrorResponse> handleAccessDenied(AccessDeniedException ex) {
-        String traceId = UUID.randomUUID().toString();
-        log.warn("Access denied traceId={}", traceId, ex);
-        ErrorResponse body = ErrorResponse.builder()
-                .code(HttpStatus.FORBIDDEN.value())
-                .message("Access denied")
-                .detail(null)
-                .traceId(traceId)
-                .build();
-        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(body);
-    }
+  @ExceptionHandler(AccessDeniedException.class)
+  public ResponseEntity<ErrorResponse> handleAccessDenied(AccessDeniedException ex, HttpServletRequest request) {
+    log.warn("Access denied", ex);
+    ErrorResponse body = buildResponse(HttpStatus.FORBIDDEN, "Access denied", request.getRequestURI());
+    return ResponseEntity.status(HttpStatus.FORBIDDEN).body(body);
+  }
 
-    @ExceptionHandler(AuthenticationException.class)
-    public ResponseEntity<ErrorResponse> handleAuthentication(AuthenticationException ex) {
-        String traceId = UUID.randomUUID().toString();
-        log.warn("Authentication failed traceId={}", traceId, ex);
-        ErrorResponse body = ErrorResponse.builder()
-                .code(HttpStatus.UNAUTHORIZED.value())
-                .message("Unauthorized")
-                .detail(null)
-                .traceId(traceId)
-                .build();
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(body);
-    }
+  @ExceptionHandler(AuthenticationException.class)
+  public ResponseEntity<ErrorResponse> handleAuthentication(AuthenticationException ex, HttpServletRequest request) {
+    log.warn("Authentication failed", ex);
+    ErrorResponse body = buildResponse(HttpStatus.UNAUTHORIZED, "Unauthorized", request.getRequestURI());
+    return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(body);
+  }
 
-    @ExceptionHandler(EntityNotFoundException.class)
-    public ResponseEntity<ErrorResponse> handleEntityNotFound(EntityNotFoundException ex) {
-        String traceId = UUID.randomUUID().toString();
-        log.warn("Entity not found traceId={}", traceId, ex);
-        ErrorResponse body = ErrorResponse.builder()
-                .code(HttpStatus.NOT_FOUND.value())
-                .message(ex.getMessage())
-                .detail(null)
-                .traceId(traceId)
-                .build();
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(body);
-    }
+  @ExceptionHandler(EntityNotFoundException.class)
+  public ResponseEntity<ErrorResponse> handleEntityNotFound(EntityNotFoundException ex, HttpServletRequest request) {
+    log.warn("Entity not found", ex);
+    ErrorResponse body = buildResponse(HttpStatus.NOT_FOUND, ex.getMessage(), request.getRequestURI());
+    return ResponseEntity.status(HttpStatus.NOT_FOUND).body(body);
+  }
 
-    @ExceptionHandler(DataIntegrityViolationException.class)
-    public ResponseEntity<ErrorResponse> handleDataIntegrityViolation(DataIntegrityViolationException ex) {
-        String traceId = UUID.randomUUID().toString();
-        log.error("Data integrity violation traceId={}", traceId, ex);
-        ErrorResponse body = ErrorResponse.builder()
-                .code(HttpStatus.CONFLICT.value())
-                .message("Data integrity violation")
-                .detail(ex.getMessage())
-                .traceId(traceId)
-                .build();
-        return ResponseEntity.status(HttpStatus.CONFLICT).body(body);
-    }
+  @ExceptionHandler(DataIntegrityViolationException.class)
+  public ResponseEntity<ErrorResponse> handleDataIntegrityViolation(DataIntegrityViolationException ex, HttpServletRequest request) {
+    log.error("Data integrity violation", ex);
+    ErrorResponse body = buildResponse(HttpStatus.CONFLICT, "Data integrity violation", request.getRequestURI());
+    return ResponseEntity.status(HttpStatus.CONFLICT).body(body);
+  }
 
-    @ExceptionHandler({OptimisticLockException.class, ObjectOptimisticLockingFailureException.class})
-    public ResponseEntity<ErrorResponse> handleOptimisticLock(Exception ex) {
-        String traceId = UUID.randomUUID().toString();
-        log.warn("Optimistic locking failure traceId={}", traceId, ex);
-        ErrorResponse body = ErrorResponse.builder()
-                .code(HttpStatus.CONFLICT.value())
-                .message("Resource version conflict")
-                .detail(ex.getMessage())
-                .traceId(traceId)
-                .build();
-        return ResponseEntity.status(HttpStatus.CONFLICT).body(body);
-    }
+  @ExceptionHandler({OptimisticLockException.class, ObjectOptimisticLockingFailureException.class})
+  public ResponseEntity<ErrorResponse> handleOptimisticLock(Exception ex, HttpServletRequest request) {
+    log.warn("Optimistic locking failure", ex);
+    ErrorResponse body = buildResponse(HttpStatus.CONFLICT, "Resource version conflict", request.getRequestURI());
+    return ResponseEntity.status(HttpStatus.CONFLICT).body(body);
+  }
 
-    @ExceptionHandler(Exception.class)
-    public ResponseEntity<ErrorResponse> handleException(Exception ex) {
-        String traceId = UUID.randomUUID().toString();
-        log.error("Unexpected exception traceId={}", traceId, ex);
-        ErrorResponse body = ErrorResponse.builder()
-                .code(HttpStatus.INTERNAL_SERVER_ERROR.value())
-                .message("Internal server error")
-                .detail(ex.getMessage())
-                .traceId(traceId)
-                .build();
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(body);
-    }
+  @ExceptionHandler(Exception.class)
+  public ResponseEntity<ErrorResponse> handleException(Exception ex, HttpServletRequest request) {
+    log.error("Unexpected exception", ex);
+    ErrorResponse body = buildResponse(HttpStatus.INTERNAL_SERVER_ERROR, "Internal server error", request.getRequestURI());
+    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(body);
+  }
+
+  private ErrorResponse buildResponse(HttpStatus status, String message, String path) {
+    ErrorResponse response = new ErrorResponse();
+    response.setStatus(status.value());
+    response.setError(status.getReasonPhrase());
+    response.setMessage(message);
+    response.setPath(path);
+    response.setTimestamp(OffsetDateTime.now().toString());
+    return response;
+  }
 }
-

--- a/src/main/java/me/quadradev/config/SwaggerConfig.java
+++ b/src/main/java/me/quadradev/config/SwaggerConfig.java
@@ -1,5 +1,6 @@
 package me.quadradev.config;
 
+import io.swagger.v3.core.converter.ModelConverters;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
@@ -8,44 +9,56 @@ import io.swagger.v3.oas.models.media.MediaType;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.oas.models.responses.ApiResponses;
-import io.swagger.v3.oas.models.security.SecurityRequirement;
-import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springdoc.core.customizers.OpenApiCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import me.quadradev.common.exception.ErrorResponse;
+
 @Configuration
 public class SwaggerConfig {
 
-    @Bean
-    public OpenAPI api() {
-        return new OpenAPI()
-                .addSecurityItem(new SecurityRequirement().addList("bearerAuth"))
-                .components(new Components().addSecuritySchemes("bearerAuth",
-                        new SecurityScheme()
-                                .type(SecurityScheme.Type.HTTP)
-                                .scheme("bearer")
-                                .bearerFormat("JWT")))
-                .info(new Info().title("API").version("1.0"));
-    }
+  @Bean
+  public OpenAPI baseOpenAPI() {
+    return new OpenAPI()
+        .components(new Components())
+        .info(new Info().title("API Generic").version("v1"));
+  }
 
-    @Bean
-    public OpenApiCustomizer errorResponses() {
-        return openApi -> openApi.getPaths().values().forEach(pathItem ->
-                pathItem.readOperations().forEach(operation -> {
-                    ApiResponses responses = operation.getResponses();
-                    responses.addApiResponse("400", errorApiResponse("Bad Request"));
-                    responses.addApiResponse("401", errorApiResponse("Unauthorized"));
-                    responses.addApiResponse("403", errorApiResponse("Forbidden"));
-                    responses.addApiResponse("404", errorApiResponse("Not Found"));
-                    responses.addApiResponse("500", errorApiResponse("Internal Server Error"));
-                }));
-    }
+  @Bean
+  public OpenApiCustomizer registerSchemasAndGlobalErrors() {
+    return openApi -> {
+      // Ensure components
+      Components components = openApi.getComponents();
+      if (components == null) {
+        components = new Components();
+        openApi.setComponents(components);
+      }
+      // 1) Register ErrorResponse schema in components.schemas
+      ModelConverters.getInstance().read(ErrorResponse.class)
+          .forEach(components::addSchemas);
 
-    private ApiResponse errorApiResponse(String description) {
-        Schema<?> schema = new Schema<>().$ref("#/components/schemas/ErrorResponse");
-        MediaType mediaType = new MediaType().schema(schema);
-        Content content = new Content().addMediaType(org.springframework.http.MediaType.APPLICATION_JSON_VALUE, mediaType);
-        return new ApiResponse().description(description).content(content);
-    }
+      // 2) Add global error responses referencing the registered schema
+      if (openApi.getPaths() == null) return;
+      openApi.getPaths().values().forEach(pathItem ->
+          pathItem.readOperations().forEach(op -> {
+            ApiResponses rs = op.getResponses();
+            addError(rs, "400", "Solicitud inválida");
+            addError(rs, "401", "No autorizado");
+            addError(rs, "403", "Prohibido");
+            addError(rs, "404", "No encontrado");
+            addError(rs, "500", "Error interno");
+          })
+      );
+    };
+  }
+
+  private void addError(ApiResponses rs, String code, String desc) {
+    if (rs.get(code) != null) return;
+    Schema<?> ref = new Schema<>().$ref("#/components/schemas/ErrorResponse");
+    MediaType mt = new MediaType().schema(ref);
+    Content content = new Content()
+        .addMediaType(org.springframework.http.MediaType.APPLICATION_JSON_VALUE, mt);
+    rs.addApiResponse(code, new ApiResponse().description(desc).content(content));
+  }
 }


### PR DESCRIPTION
## Summary
- replace Swagger configuration to register ErrorResponse schema and attach common error responses
- define ErrorResponse model with Swagger annotations and accessors
- align exception handler with new ErrorResponse format

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689cea5ace2483308e6e117792dd09bd