### PR TITLE
Handle 404 routing errors with JSON response

### DIFF
--- a/src/main/java/me/quadradev/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/me/quadradev/common/exception/GlobalExceptionHandler.java
@@ -18,6 +18,7 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.NoHandlerFoundException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -76,6 +77,13 @@ public class GlobalExceptionHandler {
     log.error("Data integrity violation", ex);
     ErrorResponse body = buildResponse(HttpStatus.CONFLICT, "Data integrity violation", request.getRequestURI());
     return ResponseEntity.status(HttpStatus.CONFLICT).body(body);
+  }
+
+  @ExceptionHandler(NoHandlerFoundException.class)
+  public ResponseEntity<ErrorResponse> handleNoHandlerFound(NoHandlerFoundException ex, HttpServletRequest request) {
+    log.warn("No handler found", ex);
+    ErrorResponse body = buildResponse(HttpStatus.NOT_FOUND, "Resource not found", request.getRequestURI());
+    return ResponseEntity.status(HttpStatus.NOT_FOUND).body(body);
   }
 
   @ExceptionHandler({OptimisticLockException.class, ObjectOptimisticLockingFailureException.class})

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -18,3 +18,6 @@ jwt.refresh-token-expiration-ms=604800000
 cors.allowed-origins=${CORS_ALLOWED_ORIGINS:http://localhost:4200}
 
 DEV_MODE=${DEV_MODE}
+
+spring.mvc.throw-exception-if-no-handler-found=true
+spring.web.resources.add-mappings=false


### PR DESCRIPTION
## Summary
- Return `ErrorResponse` JSON body when no route matches
- Enable `NoHandlerFoundException` by configuration

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for me.quadradev:api-generic)*

------
https://chatgpt.com/codex/tasks/task_e_689cf4f7ee208330bfdfcfa22bb4adac