### PR TITLE
Use existsByEmail for user updates and remove unnecessary Specification

### DIFF
--- a/src/main/java/me/quadradev/application/core/repository/UserRepository.java
+++ b/src/main/java/me/quadradev/application/core/repository/UserRepository.java
@@ -17,6 +17,7 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long>, JpaSpecificationExecutor<User> {
     List<User> findByStatus(UserStatus status);
     Optional<User> findByEmail(String email);
+    boolean existsByEmail(String email);
     @Query("SELECT u FROM User u JOIN u.roles r WHERE r.name = :roleName")
     Page<User> findUsersByRoleName(@Param("roleName") String roleName, Pageable pageable);
 }

--- a/src/main/java/me/quadradev/application/core/service/UserService.java
+++ b/src/main/java/me/quadradev/application/core/service/UserService.java
@@ -66,15 +66,13 @@ public class UserService {
 
     @Transactional
     public UserDto updateUser(Long id, UserRequest request) {
-        Specification<User> spec = Specification.where(UserSpecifications.hasId(id));
-        User existingUser = userRepository.findOne(spec)
+        User existingUser = userRepository.findById(id)
                 .orElseThrow(() -> new ApiException("User not found", HttpStatus.NOT_FOUND));
 
         if (request.email() != null && !request.email().equals(existingUser.getEmail())) {
-            Specification<User> emailSpec = Specification.where(UserSpecifications.hasEmail(request.email()));
-            userRepository.findOne(emailSpec).ifPresent(u -> {
+            if (userRepository.existsByEmail(request.email())) {
                 throw new ApiException("Email already exists", HttpStatus.CONFLICT);
-            });
+            }
             existingUser.setEmail(request.email());
         }
 


### PR DESCRIPTION
## Summary
- Add `existsByEmail` to `UserRepository`
- Simplify `UserService.updateUser` by using `findById` and duplicate email validation without `Specification`

## Testing
- `./mvnw -q test` *(fails: wget failed to fetch maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_689e149e50d88330b15eb25c917c5fc4