### PR TITLE
Add case-insensitive first name search

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ y `DB_PASSWORD`).
 Para restringir el acceso CORS de la API, define la variable `CORS_ALLOWED_ORIGINS`
 con una lista de orígenes separados por comas que podrán consumir los servicios.
 
+## Búsqueda de usuarios
+
+El endpoint `GET /api/users/search` permite filtrar usuarios por `email`, `status` y `name`.
+El parámetro `name` realiza coincidencias parciales sin distinguir entre mayúsculas y minúsculas.
+
 ## Licencia
 
 Este proyecto se distribuye bajo la licencia [MIT](LICENSE).

--- a/src/main/java/me/quadradev/application/core/specification/UserSpecifications.java
+++ b/src/main/java/me/quadradev/application/core/specification/UserSpecifications.java
@@ -38,7 +38,7 @@ public class UserSpecifications {
                 return null;
             }
             Join<User, Person> personJoin = root.join(User_.person, JoinType.INNER);
-            return cb.equal(personJoin.get(Person_.firstName), name);
+            return cb.like(cb.lower(personJoin.get(Person_.firstName)), "%" + name.toLowerCase() + "%");
         };
     }
 }


### PR DESCRIPTION
## Summary
- Support case-insensitive, partial first-name filtering in user specifications
- Document search endpoint parameters and behavior

## Testing
- `./mvnw -q test` *(fails: wget: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.11/apache-maven-3.9.11-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_689e14ab6ec08330bc52fca4d0b1902e