### PR TITLE
Return tokens in auth responses

### DIFF
--- a/src/main/java/me/quadradev/application/auth/AuthController.java
+++ b/src/main/java/me/quadradev/application/auth/AuthController.java
@@ -14,20 +14,20 @@ public class AuthController {
     private final AuthService authService;
 
     @PostMapping("/login")
-    public ResponseEntity<Void> login(@RequestBody @Valid LoginRequest request) {
+    public ResponseEntity<AuthTokens> login(@RequestBody @Valid LoginRequest request) {
         AuthTokens tokens = authService.login(request.email(), request.password());
         return ResponseEntity.ok()
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + tokens.accessToken())
                 .header("Refresh-Token", tokens.refreshToken())
-                .build();
+                .body(tokens);
     }
 
     @PostMapping("/refresh")
-    public ResponseEntity<Void> refresh(@RequestHeader("Refresh-Token") String refreshToken) {
+    public ResponseEntity<AuthTokens> refresh(@RequestHeader("Refresh-Token") String refreshToken) {
         AuthTokens tokens = authService.refreshAccessToken(refreshToken);
         return ResponseEntity.ok()
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + tokens.accessToken())
                 .header("Refresh-Token", tokens.refreshToken())
-                .build();
+                .body(tokens);
     }
 }


### PR DESCRIPTION
## Summary
- Return authentication tokens in `login` and `refresh` endpoints via response body while preserving headers.

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689e258c8da88330b8e75910f77e59af