### PR TITLE
feat(auth): include user data in JWT

### DIFF
--- a/src/main/java/me/quadradev/common/security/JwtProvider.java
+++ b/src/main/java/me/quadradev/common/security/JwtProvider.java
@@ -12,7 +12,12 @@ import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Collectors;
+
+import me.quadradev.application.core.model.Role;
+import me.quadradev.application.core.model.User;
 
 @Component
 @RequiredArgsConstructor
@@ -40,12 +45,36 @@ public class JwtProvider {
         return generateToken(Collections.emptyMap(), subject, expirationMs);
     }
 
-    public String generateAccessToken(String email) {
-        return generateToken(email, jwtProperties.getAccessTokenExpirationMs());
+    public String generateAccessToken(Map<String, Object> claims, String email) {
+        return generateToken(claims, email, jwtProperties.getAccessTokenExpirationMs());
     }
 
-    public String generateRefreshToken(String email) {
-        return generateToken(email, jwtProperties.getRefreshTokenExpirationMs());
+    public String generateRefreshToken(Map<String, Object> claims, String email) {
+        return generateToken(claims, email, jwtProperties.getRefreshTokenExpirationMs());
+    }
+
+    public String generateAccessToken(User user) {
+        return generateAccessToken(buildClaims(user), user.getEmail());
+    }
+
+    public String generateRefreshToken(User user) {
+        return generateRefreshToken(buildClaims(user), user.getEmail());
+    }
+
+    private Map<String, Object> buildClaims(User user) {
+        Map<String, Object> claims = new HashMap<>();
+        claims.put("id", user.getId());
+        claims.put("email", user.getEmail());
+        claims.put("roles", user.getRoles().stream().map(Role::getName).collect(Collectors.toList()));
+        return claims;
+    }
+
+    public long getAccessTokenExpirationMs() {
+        return jwtProperties.getAccessTokenExpirationMs();
+    }
+
+    public long getRefreshTokenExpirationMs() {
+        return jwtProperties.getRefreshTokenExpirationMs();
     }
 
     public boolean validateToken(String token) {


### PR DESCRIPTION
## Summary
- include user id, email and roles in generated tokens
- expose helpers to generate tokens from claim maps or User objects

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689e2ff2cd088330b9561d4cee7ed87e