### PR TITLE
Use claims to build UserPrincipal in JwtFilter

### DIFF
--- a/src/main/java/me/quadradev/common/security/UserPrincipal.java
+++ b/src/main/java/me/quadradev/common/security/UserPrincipal.java
@@ -1,0 +1,5 @@
+package me.quadradev.common.security;
+
+import java.util.List;
+
+public record UserPrincipal(Long id, String email, List<String> roles) {}


### PR DESCRIPTION
## Summary
- Build `UserPrincipal` (id, email, roles) from JWT claims
- Replace token email lookup with claim parsing in `JwtFilter`
- Map JWT roles to Spring authorities

## Testing
- `mvn -q test -DskipTests` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_689e32b14bd48330bdc4accbb659f389