### PR TITLE
refactor: convert error response to record

### DIFF
--- a/src/main/java/me/quadradev/common/exception/ErrorResponse.java
+++ b/src/main/java/me/quadradev/common/exception/ErrorResponse.java
@@ -3,21 +3,10 @@ package me.quadradev.common.exception;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(name = "ErrorResponse", description = "Formato estándar de error")
-public class ErrorResponse {
-  @Schema(example = "404") private Integer status;
-  @Schema(example = "Not Found") private String error;
-  @Schema(example = "Recurso no encontrado") private String message;
-  @Schema(example = "/api/users/123") private String path;
-  @Schema(example = "2025-08-13T19:05:00Z") private String timestamp;
-
-  public Integer getStatus() { return status; }
-  public void setStatus(Integer status) { this.status = status; }
-  public String getError() { return error; }
-  public void setError(String error) { this.error = error; }
-  public String getMessage() { return message; }
-  public void setMessage(String message) { this.message = message; }
-  public String getPath() { return path; }
-  public void setPath(String path) { this.path = path; }
-  public String getTimestamp() { return timestamp; }
-  public void setTimestamp(String timestamp) { this.timestamp = timestamp; }
-}
+public record ErrorResponse(
+    @Schema(example = "404") Integer status,
+    @Schema(example = "Not Found") String error,
+    @Schema(example = "Recurso no encontrado") String message,
+    @Schema(example = "/api/users/123") String path,
+    @Schema(example = "2025-08-13T19:05:00Z") String timestamp
+) {}

--- a/src/main/java/me/quadradev/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/me/quadradev/common/exception/GlobalExceptionHandler.java
@@ -101,12 +101,11 @@ public class GlobalExceptionHandler {
   }
 
   private ErrorResponse buildResponse(HttpStatus status, String message, String path) {
-    ErrorResponse response = new ErrorResponse();
-    response.setStatus(status.value());
-    response.setError(status.getReasonPhrase());
-    response.setMessage(message);
-    response.setPath(path);
-    response.setTimestamp(OffsetDateTime.now().toString());
-    return response;
+    return new ErrorResponse(
+        status.value(),
+        status.getReasonPhrase(),
+        message,
+        path,
+        OffsetDateTime.now().toString());
   }
 }


### PR DESCRIPTION
## Summary
- refactor ErrorResponse into a Java record with OpenAPI schema annotations
- update GlobalExceptionHandler to construct the new record instance

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689e3a3ec5288330b7810552c593b615