### PR TITLE
Add initial unit tests for utilities and JWT provider

### DIFF
--- a/src/test/java/me/quadradev/common/security/JwtProviderTest.java
+++ b/src/test/java/me/quadradev/common/security/JwtProviderTest.java
@@ -1,0 +1,44 @@
+package me.quadradev.common.security;
+
+import io.jsonwebtoken.Claims;
+import me.quadradev.application.core.model.Role;
+import me.quadradev.application.core.model.User;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class JwtProviderTest {
+
+    private JwtProvider buildProvider() {
+        JwtProperties properties = new JwtProperties();
+        properties.setSecret("0123456789ABCDEF0123456789ABCDEF");
+        properties.setAccessTokenExpirationMs(3600000); // 1 hour
+        properties.setRefreshTokenExpirationMs(7200000); // 2 hours
+        return new JwtProvider(properties);
+    }
+
+    private User buildUser() {
+        return User.builder()
+                .id(1L)
+                .email("user@example.com")
+                .roles(Set.of(Role.builder().name("ADMIN").build()))
+                .build();
+    }
+
+    @Test
+    void generateTokenAndValidateClaims() {
+        JwtProvider provider = buildProvider();
+        User user = buildUser();
+
+        String token = provider.generateAccessToken(user);
+        assertTrue(provider.validateToken(token));
+        assertEquals(user.getEmail(), provider.getEmailFromToken(token));
+
+        Claims claims = provider.getClaims(token);
+        assertEquals(1L, ((Number) claims.get("id")).longValue());
+        assertEquals(user.getEmail(), claims.get("email"));
+        assertTrue(((java.util.List<?>) claims.get("roles")).contains("ADMIN"));
+    }
+}

--- a/src/test/java/me/quadradev/common/util/ApiResponseTest.java
+++ b/src/test/java/me/quadradev/common/util/ApiResponseTest.java
@@ -1,0 +1,38 @@
+package me.quadradev.common.util;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ApiResponseTest {
+
+    @Test
+    void okShouldBuildSuccessfulResponse() {
+        ApiResponse<String> response = ApiResponse.ok("message", "data");
+        assertTrue(response.isSuccess());
+        assertEquals(200, response.getStatus());
+        assertEquals("message", response.getMessage());
+        assertEquals("data", response.getData());
+        assertNull(response.getError());
+    }
+
+    @Test
+    void createdShouldBuildCreatedResponse() {
+        ApiResponse<String> response = ApiResponse.created("created", "id");
+        assertTrue(response.isSuccess());
+        assertEquals(201, response.getStatus());
+        assertEquals("created", response.getMessage());
+        assertEquals("id", response.getData());
+        assertNull(response.getError());
+    }
+
+    @Test
+    void errorShouldBuildErrorResponse() {
+        Object details = new Object();
+        ApiResponse<String> response = ApiResponse.error(400, "bad", details);
+        assertFalse(response.isSuccess());
+        assertEquals(400, response.getStatus());
+        assertEquals("bad", response.getMessage());
+        assertNull(response.getData());
+        assertSame(details, response.getError());
+    }
+}

--- a/src/test/java/me/quadradev/common/util/PageResponseTest.java
+++ b/src/test/java/me/quadradev/common/util/PageResponseTest.java
@@ -1,0 +1,25 @@
+package me.quadradev.common.util;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PageResponseTest {
+
+    @Test
+    void ofShouldMapPageFieldsCorrectly() {
+        Page<String> page = new PageImpl<>(List.of("a", "b"), PageRequest.of(0, 2), 5);
+        PageResponse<String> response = PageResponse.of(page);
+        assertEquals(page.getContent(), response.content());
+        assertEquals(0, response.page());
+        assertEquals(2, response.size());
+        assertEquals(5, response.totalElements());
+        assertEquals(3, response.totalPages());
+        assertFalse(response.last());
+    }
+}


### PR DESCRIPTION
## Summary
- test ApiResponse builder methods
- test PageResponse conversion logic
- test JwtProvider token generation and claim parsing

## Testing
- `./mvnw -q test` *(fails: wget failed to fetch Maven)*
- `mvn -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689e3c5bf36c8330baa5bb78277076f9