### PR TITLE
Agregar pruebas unitarias para servicios principales

### DIFF
--- a/src/test/java/me/quadradev/application/auth/AuthServiceTest.java
+++ b/src/test/java/me/quadradev/application/auth/AuthServiceTest.java
@@ -1,0 +1,70 @@
+package me.quadradev.application.auth;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import me.quadradev.application.core.model.Role;
+import me.quadradev.application.core.model.User;
+import me.quadradev.application.core.model.UserStatus;
+import me.quadradev.application.core.repository.UserRepository;
+import me.quadradev.common.exception.ApiException;
+import me.quadradev.common.security.JwtProvider;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private JwtProvider jwtProvider;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    private AuthService authService;
+
+    @Test
+    void loginReturnsTokensWhenCredentialsAreValid() {
+        User user = User.builder()
+                .id(1L)
+                .email("user@example.com")
+                .password("encoded")
+                .status(UserStatus.ACTIVE)
+                .roles(Set.of(Role.builder().name("ADMIN").build()))
+                .build();
+
+        when(userRepository.findByEmail("user@example.com")).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches("secret", "encoded")).thenReturn(true);
+        when(jwtProvider.generateToken(anyMap(), eq(user.getEmail()), anyLong()))
+                .thenReturn("access").thenReturn("refresh");
+
+        AuthTokens tokens = authService.login("user@example.com", "secret");
+
+        assertEquals("access", tokens.accessToken());
+        assertEquals("refresh", tokens.refreshToken());
+    }
+
+    @Test
+    void refreshAccessTokenExpiredThrowsApiException() {
+        when(jwtProvider.getEmailFromToken("bad")).thenThrow(new ExpiredJwtException(null, null, "exp"));
+
+        ApiException ex = assertThrows(ApiException.class, () -> authService.refreshAccessToken("bad"));
+        assertEquals("Refresh token expirado", ex.getMessage());
+        assertEquals(HttpStatus.UNAUTHORIZED, ex.getStatus());
+    }
+}
+

--- a/src/test/java/me/quadradev/application/core/service/MenuServiceTest.java
+++ b/src/test/java/me/quadradev/application/core/service/MenuServiceTest.java
@@ -1,0 +1,67 @@
+package me.quadradev.application.core.service;
+
+import me.quadradev.application.core.dto.MenuNodeDto;
+import me.quadradev.application.core.model.*;
+import me.quadradev.application.core.repository.MenuRepository;
+import me.quadradev.application.core.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class MenuServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private MenuRepository menuRepository;
+
+    @InjectMocks
+    private MenuService menuService;
+
+    @Test
+    void getMenuTreeForUserBuildsTree() {
+        Menu child = Menu.builder().id(2L).code("child").name("Child").build();
+        Menu root = Menu.builder().id(1L).code("root").name("Root").children(Set.of(child)).build();
+        child.setParent(root);
+
+        RoleMenuPermission permRoot = RoleMenuPermission.builder()
+                .menu(root)
+                .permissions(MenuAction.toMask(Set.of(MenuAction.VIEW, MenuAction.CREATE)))
+                .build();
+        RoleMenuPermission permChild = RoleMenuPermission.builder()
+                .menu(child)
+                .permissions(MenuAction.toMask(Set.of(MenuAction.VIEW)))
+                .build();
+
+        Role role = Role.builder().menuPermissions(Set.of(permRoot, permChild)).build();
+        User user = User.builder().email("user@example.com").roles(Set.of(role)).build();
+        when(userRepository.findByEmail("user@example.com")).thenReturn(Optional.of(user));
+
+        List<MenuNodeDto> tree = menuService.getMenuTreeForUser("user@example.com");
+        assertEquals(1, tree.size());
+        MenuNodeDto rootNode = tree.get(0);
+        assertEquals(1L, rootNode.id());
+        assertTrue(rootNode.actions().contains(MenuAction.VIEW));
+        assertTrue(rootNode.actions().contains(MenuAction.CREATE));
+        assertEquals(1, rootNode.children().size());
+        assertEquals(2L, rootNode.children().get(0).id());
+    }
+
+    @Test
+    void getMenuTreeForUserUserNotFoundThrows() {
+        when(userRepository.findByEmail("missing@example.com")).thenReturn(Optional.empty());
+        assertThrows(RuntimeException.class, () -> menuService.getMenuTreeForUser("missing@example.com"));
+    }
+}
+

--- a/src/test/java/me/quadradev/application/core/service/RoleServiceTest.java
+++ b/src/test/java/me/quadradev/application/core/service/RoleServiceTest.java
@@ -1,0 +1,91 @@
+package me.quadradev.application.core.service;
+
+import me.quadradev.application.core.dto.RoleRequest;
+import me.quadradev.application.core.dto.UserDto;
+import me.quadradev.application.core.mapper.RoleMapper;
+import me.quadradev.application.core.mapper.UserMapper;
+import me.quadradev.application.core.model.*;
+import me.quadradev.application.core.repository.MenuRepository;
+import me.quadradev.application.core.repository.RoleMenuPermissionRepository;
+import me.quadradev.application.core.repository.RoleRepository;
+import me.quadradev.application.core.repository.UserRepository;
+import me.quadradev.common.exception.ApiException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class RoleServiceTest {
+
+    @Mock
+    private RoleRepository roleRepository;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private MenuRepository menuRepository;
+    @Mock
+    private RoleMenuPermissionRepository roleMenuPermissionRepository;
+    @Mock
+    private RoleMapper roleMapper;
+    @Mock
+    private UserMapper userMapper;
+
+    @InjectMocks
+    private RoleService roleService;
+
+    @Test
+    void createRoleThrowsWhenNameExists() {
+        RoleRequest request = new RoleRequest("ADMIN");
+        when(roleRepository.findByName("ADMIN")).thenReturn(Optional.of(Role.builder().build()));
+
+        ApiException ex = assertThrows(ApiException.class, () -> roleService.createRole(request));
+        assertEquals("Role already exists", ex.getMessage());
+        assertEquals(HttpStatus.CONFLICT, ex.getStatus());
+    }
+
+    @Test
+    void assignRolesToUserAddsRoles() {
+        User user = User.builder().id(1L).roles(new java.util.HashSet<>()).build();
+        Role role = Role.builder().name("ADMIN").build();
+        UserDto dto = new UserDto(1L, null, null, null, null, null, UserStatus.ACTIVE, Set.of("ADMIN"));
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(roleRepository.findByName("ADMIN")).thenReturn(Optional.of(role));
+        when(userRepository.save(user)).thenReturn(user);
+        when(userMapper.toDto(user)).thenReturn(dto);
+
+        UserDto result = roleService.assignRolesToUser(1L, Set.of("ADMIN"));
+        assertEquals(dto, result);
+        assertTrue(user.getRoles().contains(role));
+    }
+
+    @Test
+    void updateMenuPermissionsSavesMask() {
+        Role role = Role.builder().id(1L).build();
+        Menu menu = Menu.builder().id(2L).build();
+
+        when(roleRepository.findById(1L)).thenReturn(Optional.of(role));
+        when(menuRepository.findById(2L)).thenReturn(Optional.of(menu));
+        when(roleMenuPermissionRepository.findByRoleAndMenu(role, menu)).thenReturn(Optional.empty());
+
+        roleService.updateMenuPermissions(1L, 2L, Set.of(MenuAction.VIEW, MenuAction.CREATE));
+
+        ArgumentCaptor<RoleMenuPermission> captor = ArgumentCaptor.forClass(RoleMenuPermission.class);
+        verify(roleMenuPermissionRepository).save(captor.capture());
+        RoleMenuPermission saved = captor.getValue();
+        assertEquals(MenuAction.toMask(Set.of(MenuAction.VIEW, MenuAction.CREATE)), saved.getPermissions());
+        assertEquals(role, saved.getRole());
+        assertEquals(menu, saved.getMenu());
+    }
+}
+

--- a/src/test/java/me/quadradev/application/core/service/UserServiceTest.java
+++ b/src/test/java/me/quadradev/application/core/service/UserServiceTest.java
@@ -1,0 +1,67 @@
+package me.quadradev.application.core.service;
+
+import me.quadradev.application.core.dto.UserDto;
+import me.quadradev.application.core.dto.UserRequest;
+import me.quadradev.application.core.mapper.UserMapper;
+import me.quadradev.application.core.model.User;
+import me.quadradev.application.core.model.UserStatus;
+import me.quadradev.application.core.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private UserMapper userMapper;
+
+    @InjectMocks
+    private UserService userService;
+
+    @Test
+    void createUserEncodesPasswordAndReturnsDto() {
+        UserRequest request = new UserRequest("user@example.com", "secret", "John", null, "Doe", null, UserStatus.ACTIVE);
+        User user = User.builder().email(request.email()).password(request.password()).status(UserStatus.ACTIVE).build();
+        User saved = User.builder().id(1L).email(request.email()).password("encoded").status(UserStatus.ACTIVE).build();
+        UserDto dto = new UserDto(1L, request.email(), request.firstName(), null, request.lastName(), null, UserStatus.ACTIVE, Set.of());
+
+        when(userRepository.findByEmail(request.email())).thenReturn(Optional.empty());
+        when(userMapper.toEntity(request)).thenReturn(user);
+        when(passwordEncoder.encode(request.password())).thenReturn("encoded");
+        when(userRepository.save(any(User.class))).thenReturn(saved);
+        when(userMapper.toDto(saved)).thenReturn(dto);
+
+        UserDto result = userService.createUser(request);
+        assertEquals(dto, result);
+        verify(passwordEncoder).encode("secret");
+    }
+
+    @Test
+    void deactivateUserSetsStatusInactive() {
+        User user = User.builder().id(1L).status(UserStatus.ACTIVE).build();
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+        userService.deactivateUser(1L);
+
+        assertEquals(UserStatus.INACTIVE, user.getStatus());
+        verify(userRepository).save(user);
+    }
+}
+


### PR DESCRIPTION
## Resumen
- Añade pruebas unitarias para AuthService.
- Cubre la construcción de árbol de menús en MenuService.
- Valida creación, desactivación y roles de usuario en servicios de dominio.

## Pruebas
- `./mvnw -q test` *(falla: wget no pudo descargar dependencias de Maven)*
- `mvn -q test` *(falla: no se pudo resolver el parent POM por falta de acceso a Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_689e8268816483308eb3b276e0ca8901