### PR TITLE
Add tests for AuthService error scenarios

### DIFF
--- a/src/test/java/me/quadradev/application/auth/AuthServiceTest.java
+++ b/src/test/java/me/quadradev/application/auth/AuthServiceTest.java
@@ -1,6 +1,7 @@
 package me.quadradev.application.auth;
 
 import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
 import me.quadradev.application.core.model.Role;
 import me.quadradev.application.core.model.User;
 import me.quadradev.application.core.model.UserStatus;
@@ -59,11 +60,70 @@ class AuthServiceTest {
     }
 
     @Test
+    void loginThrowsApiExceptionWhenUserNotFound() {
+        when(userRepository.findByEmail("missing@example.com")).thenReturn(Optional.empty());
+
+        ApiException ex = assertThrows(ApiException.class, () -> authService.login("missing@example.com", "pwd"));
+        assertEquals("Credenciales inválidas", ex.getMessage());
+        assertEquals(HttpStatus.UNAUTHORIZED, ex.getStatus());
+    }
+
+    @Test
+    void loginThrowsApiExceptionWhenUserInactive() {
+        User inactive = User.builder()
+                .email("user@example.com")
+                .password("encoded")
+                .status(UserStatus.INACTIVE)
+                .build();
+
+        when(userRepository.findByEmail("user@example.com")).thenReturn(Optional.of(inactive));
+
+        ApiException ex = assertThrows(ApiException.class, () -> authService.login("user@example.com", "secret"));
+        assertEquals("Usuario inactivo", ex.getMessage());
+        assertEquals(HttpStatus.FORBIDDEN, ex.getStatus());
+    }
+
+    @Test
+    void loginThrowsApiExceptionWhenPasswordInvalid() {
+        User user = User.builder()
+                .email("user@example.com")
+                .password("encoded")
+                .status(UserStatus.ACTIVE)
+                .build();
+
+        when(userRepository.findByEmail("user@example.com")).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches("wrong", "encoded")).thenReturn(false);
+
+        ApiException ex = assertThrows(ApiException.class, () -> authService.login("user@example.com", "wrong"));
+        assertEquals("Credenciales inválidas", ex.getMessage());
+        assertEquals(HttpStatus.UNAUTHORIZED, ex.getStatus());
+    }
+
+    @Test
     void refreshAccessTokenExpiredThrowsApiException() {
         when(jwtProvider.getEmailFromToken("bad")).thenThrow(new ExpiredJwtException(null, null, "exp"));
 
         ApiException ex = assertThrows(ApiException.class, () -> authService.refreshAccessToken("bad"));
         assertEquals("Refresh token expirado", ex.getMessage());
+        assertEquals(HttpStatus.UNAUTHORIZED, ex.getStatus());
+    }
+
+    @Test
+    void refreshAccessTokenUserNotFoundThrowsApiException() {
+        when(jwtProvider.getEmailFromToken("token")).thenReturn("user@example.com");
+        when(userRepository.findByEmail("user@example.com")).thenReturn(Optional.empty());
+
+        ApiException ex = assertThrows(ApiException.class, () -> authService.refreshAccessToken("token"));
+        assertEquals("Usuario no encontrado", ex.getMessage());
+        assertEquals(HttpStatus.UNAUTHORIZED, ex.getStatus());
+    }
+
+    @Test
+    void refreshAccessTokenInvalidTokenThrowsApiException() {
+        when(jwtProvider.getEmailFromToken("bad")).thenThrow(new JwtException("bad"));
+
+        ApiException ex = assertThrows(ApiException.class, () -> authService.refreshAccessToken("bad"));
+        assertEquals("Refresh token inválido", ex.getMessage());
         assertEquals(HttpStatus.UNAUTHORIZED, ex.getStatus());
     }
 }


### PR DESCRIPTION
## Summary
- add unit tests for invalid login cases
- cover refresh token errors in AuthService

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for me.quadradev:api-generic:0.0.1-SNAPSHOT)*

------
https://chatgpt.com/codex/tasks/task_e_689e87476dc88330a030fad89564dd2b